### PR TITLE
Add custom type guards to validate enum type and satisfy compiler type checks.

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,11 @@
+import { ApplicationStageType } from '@prisma/client';
 import { Auth, GithubAuthProvider, signInWithRedirect, signOut, User } from 'firebase/auth';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useContext, useEffect, useState } from 'react';
 import AuthContext from '../context/AuthContext';
 import styles from '../styles/Home.module.css';
+import { isApplicationStageType } from '../utils/types';
 
 const Home: NextPage = () => {
   const { auth, currentUser } = useContext(AuthContext);
@@ -38,11 +40,32 @@ const Home: NextPage = () => {
               jwt.io
             </a>
           </p>
+          <p>{foo('APPLIED')}</p>
+          <p>{foo('ONLINE_ASSESSMENT')}</p>
+          <p>{foo('TECHNICAL')}</p>
+          <p>{foo('NON_TECHNICAL')}</p>
+          <p>{foo('MIXED')}</p>
+          <p>{foo('OFFERED')}</p>
+          <p>{foo('ACCEPTED')}</p>
+          <p>{foo('REJECTED')}</p>
+          <p>{foo('WITHDRAWN')}</p>
+          <p>{foo(null)}</p>
+          <p>{foo(undefined)}</p>
+          <p>{foo({})}</p>
+          <p>{foo({ APPLIED: true })}</p>
+          <p>{foo(['APPLIED'])}</p>
         </div>
       </main>
     </div>
   );
 };
+
+const foo = (x: any) => `${x} : ${isApplicationStageType(x)}`;
+function testCustomGuard(x: any) {
+  if (!isApplicationStageType(x)) return;
+  let y: ApplicationStageType;
+  y = x; // Compiler does not complain!
+}
 
 function displayUserInfo(user: User | undefined) {
   if (!user) return <>Failed to get user!</>;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,9 @@
-import { ApplicationStageType } from '@prisma/client';
 import { Auth, GithubAuthProvider, signInWithRedirect, signOut, User } from 'firebase/auth';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useContext, useEffect, useState } from 'react';
 import AuthContext from '../context/AuthContext';
 import styles from '../styles/Home.module.css';
-import { isApplicationStageType } from '../utils/types';
 
 const Home: NextPage = () => {
   const { auth, currentUser } = useContext(AuthContext);
@@ -40,32 +38,11 @@ const Home: NextPage = () => {
               jwt.io
             </a>
           </p>
-          <p>{foo('APPLIED')}</p>
-          <p>{foo('ONLINE_ASSESSMENT')}</p>
-          <p>{foo('TECHNICAL')}</p>
-          <p>{foo('NON_TECHNICAL')}</p>
-          <p>{foo('MIXED')}</p>
-          <p>{foo('OFFERED')}</p>
-          <p>{foo('ACCEPTED')}</p>
-          <p>{foo('REJECTED')}</p>
-          <p>{foo('WITHDRAWN')}</p>
-          <p>{foo(null)}</p>
-          <p>{foo(undefined)}</p>
-          <p>{foo({})}</p>
-          <p>{foo({ APPLIED: true })}</p>
-          <p>{foo(['APPLIED'])}</p>
         </div>
       </main>
     </div>
   );
 };
-
-const foo = (x: any) => `${x} : ${isApplicationStageType(x)}`;
-function testCustomGuard(x: any) {
-  if (!isApplicationStageType(x)) return;
-  let y: ApplicationStageType;
-  y = x; // Compiler does not complain!
-}
 
 function displayUserInfo(user: User | undefined) {
   if (!user) return <>Failed to get user!</>;

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -1,0 +1,13 @@
+import { ApplicationStageType, RoleType } from '@prisma/client';
+
+/** Custom type guard for RoleType enum. */
+export function isRoleType(obj: any): obj is RoleType {
+  if (typeof obj != 'string') return false;
+  return Object.values(RoleType).find((v) => v.localeCompare(obj) === 0) != undefined;
+}
+
+/** Custom type guard for ApplicationStageType enum. */
+export function isApplicationStageType(obj: any): obj is ApplicationStageType {
+  if (typeof obj != 'string') return false;
+  return Object.values(ApplicationStageType).find((v) => v.localeCompare(obj) === 0) != undefined;
+}

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -1,13 +1,13 @@
 import { ApplicationStageType, RoleType } from '@prisma/client';
 
 /** Custom type guard for RoleType enum. */
-export function isRoleType(obj: any): obj is RoleType {
+export function isRoleType(obj: unknown): obj is RoleType {
   if (typeof obj != 'string') return false;
   return Object.values(RoleType).find((v) => v.localeCompare(obj) === 0) != undefined;
 }
 
 /** Custom type guard for ApplicationStageType enum. */
-export function isApplicationStageType(obj: any): obj is ApplicationStageType {
+export function isApplicationStageType(obj: unknown): obj is ApplicationStageType {
   if (typeof obj != 'string') return false;
   return Object.values(ApplicationStageType).find((v) => v.localeCompare(obj) === 0) != undefined;
 }


### PR DESCRIPTION
Type guards are necessary to validate an object as a particular type and also to appease the compiler's type-checking.
For typescript compiler to accept an object as a enum value, typical `instanceof` or `typeof` solutions do not work.

See here for more details on how this type guard works: https://stackoverflow.com/questions/56044872/typescript-enum-object-values-return-value/56044932#56044932

Checkout the second commit to see how I tested it (did both runtime & compiler tests):

- Create custom type guards for the two enums.
- Test the custom type guard out.
- Revert "Test the custom type guard out."
