### PR TITLE
Add companies api

### DIFF
--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { CompanyData, CompanyListData, CompanyPostData } from '../../types/company';
 import { isEmpty, isValidUrl } from '../../utils/strings/validations';
-import { capitalizeEveryWord, removeProtocolAndWwwIfPresent } from '../../utils/strings/formatters';
+import {capitalizeEveryWord, removeProtocolAndWwwIfPresent, trim} from '../../utils/strings/formatters';
 import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '../../utils/http/httpHelpers';
 import { withAuth } from '../../utils/auth/jwtHelpers';
 import { ApiResponse, StatusMessageType } from '../../types/apiResponse';
@@ -49,7 +49,7 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
 
 async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<CompanyListData[]>>) {
   const { name } = req.query;
-  const trimmedName = name && name.toString().trim();
+  const trimmedName = name && trim(name);
 
   if (!trimmedName) {
     res.status(HttpStatus.OK).json(createJsonResponse([]));

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -49,9 +49,9 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
 
 async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<CompanyListData[]>>) {
   const { name } = req.query;
-  const trimmedNameKeyword = name && name.toString().trim();
+  const trimmedName = name && name.toString().trim();
 
-  if (!trimmedNameKeyword) {
+  if (!trimmedName) {
     res.status(HttpStatus.OK).json(createJsonResponse([]));
     return;
   }
@@ -60,7 +60,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<C
     where: {
       isVerified: true,
       name: {
-        contains: trimmedNameKeyword,
+        contains: trimmedName,
         mode: 'insensitive',
       },
     },

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -36,7 +36,7 @@ function handler(_: string, req: NextApiRequest, res: NextApiResponse) {
       handlePost(req, res);
       break;
     default:
-      rejectHttpMethodsNotIn(res, HTTP_POST_METHOD);
+      rejectHttpMethodsNotIn(res, HTTP_GET_METHOD, HTTP_POST_METHOD);
   }
 }
 

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -1,5 +1,59 @@
+import { PrismaClient } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  HTTP_POST_METHOD,
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_CREATED,
+  rejectHttpMethodsNotIn,
+} from '../../utils/http/httpHelpers';
+import { CompanyPostData } from '../../types/company';
+import { isEmpty, isValidUrl } from '../../utils/strings/validations';
+import { ErrorData } from '../../types/error';
+import { withAnyUser } from '../../utils/auth/jwtHelpers';
+import { removeProtocolAndWwwIfPresent } from '../../utils/strings/formatters';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).end(`Request sent to ${req.url}\n`);
+enum ErrorType {
+  EMPTY_NAME,
+  INVALID_URL,
 }
+
+const prisma = new PrismaClient();
+
+const errorMessages = new Map<ErrorType, ErrorData>([
+  [ErrorType.EMPTY_NAME, { message: 'Company name must not be empty.' }],
+  [ErrorType.INVALID_URL, { message: 'Company url is invalid.' }],
+]);
+
+function handler(userId: string, req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method;
+  switch (method) {
+    case HTTP_POST_METHOD:
+      handlePost(userId, req, res);
+      break;
+    default:
+      rejectHttpMethodsNotIn(res, HTTP_POST_METHOD);
+  }
+}
+
+async function handlePost(userId: string, req: NextApiRequest, res: NextApiResponse) {
+  const companyPostData: CompanyPostData = req.body;
+
+  if (isEmpty(companyPostData.name)) {
+    return res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.EMPTY_NAME));
+  }
+
+  if (!isValidUrl(companyPostData.companyUrl)) {
+    return res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.INVALID_URL));
+  }
+
+  const newCompany = await prisma.company.create({
+    data: {
+      name: companyPostData.name,
+      companyUrl: removeProtocolAndWwwIfPresent(companyPostData.companyUrl),
+    },
+  });
+
+  res.status(HTTP_STATUS_CREATED).json(newCompany);
+}
+
+export default withAnyUser(handler);

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -48,8 +48,8 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<CompanyListData[]>>) {
-  const { nameKeyword } = req.query;
-  const trimmedNameKeyword = nameKeyword && nameKeyword.toString().trim();
+  const { name } = req.query;
+  const trimmedNameKeyword = name && name.toString().trim();
 
   if (!trimmedNameKeyword) {
     res.status(HttpStatus.OK).json(createJsonResponse([]));

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -1,42 +1,36 @@
 import { PrismaClient } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import {
-  HTTP_GET_METHOD,
-  HTTP_POST_METHOD,
-  HTTP_STATUS_BAD_REQUEST,
-  HTTP_STATUS_CREATED,
-  HTTP_STATUS_OK,
-  rejectHttpMethodsNotIn,
-} from '../../utils/http/httpHelpers';
 import { CompanyListData, CompanyPostData } from '../../types/company';
 import { isEmpty, isValidUrl } from '../../utils/strings/validations';
 import { ErrorData } from '../../types/error';
-import { withAnyUser } from '../../utils/auth/jwtHelpers';
 import { removeProtocolAndWwwIfPresent } from '../../utils/strings/formatters';
+import { HttpMethod, HttpStatus, rejectHttpMethod } from '../../utils/http/httpHelpers';
+import { withAuthUser } from '../../utils/auth/jwtHelpers';
 
-enum ErrorType {
+enum MessageType {
   EMPTY_NAME,
-  INVALID_URL,
+  INVALID_COMPANY_URL,
 }
 
 const prisma = new PrismaClient();
 
-const errorMessages = new Map<ErrorType, ErrorData>([
-  [ErrorType.EMPTY_NAME, { message: 'Company name must not be empty.' }],
-  [ErrorType.INVALID_URL, { message: 'Company url is invalid.' }],
+const errorMessages = new Map<MessageType, ErrorData>([
+  [MessageType.EMPTY_NAME, { message: 'Company name must not be empty.' }],
+  [MessageType.INVALID_COMPANY_URL, { message: 'Company url is invalid.' }],
 ]);
 
 function handler(_: string, req: NextApiRequest, res: NextApiResponse) {
   const method = req.method;
+
   switch (method) {
-    case HTTP_GET_METHOD:
+    case HttpMethod.GET:
       handleGet(req, res);
       break;
-    case HTTP_POST_METHOD:
+    case HttpMethod.POST:
       handlePost(req, res);
       break;
     default:
-      rejectHttpMethodsNotIn(res, HTTP_GET_METHOD, HTTP_POST_METHOD);
+      rejectHttpMethod(res, method);
   }
 }
 
@@ -46,19 +40,19 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
     select: { id: true, name: true, companyUrl: true },
   });
 
-  res.status(HTTP_STATUS_OK).json(companies);
+  res.status(HttpStatus.OK).json(companies);
 }
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   const companyPostData: CompanyPostData = req.body;
 
   if (isEmpty(companyPostData.name)) {
-    res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.EMPTY_NAME));
+    res.status(HttpStatus.BAD_REQUEST).json(errorMessages.get(MessageType.EMPTY_NAME));
     return;
   }
 
   if (!isValidUrl(companyPostData.companyUrl)) {
-    res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.INVALID_URL));
+    res.status(HttpStatus.BAD_REQUEST).json(errorMessages.get(MessageType.INVALID_COMPANY_URL));
     return;
   }
 
@@ -69,7 +63,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     },
   });
 
-  res.status(HTTP_STATUS_CREATED).json(newCompany);
+  res.status(HttpStatus.CREATED).json(newCompany);
 }
 
-export default withAnyUser(handler);
+export default withAuthUser(handler);

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -45,6 +45,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
     where: { isVerified: true },
     select: { id: true, name: true, companyUrl: true },
   });
+
   res.status(HTTP_STATUS_OK).json(companies);
 }
 
@@ -52,11 +53,13 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   const companyPostData: CompanyPostData = req.body;
 
   if (isEmpty(companyPostData.name)) {
-    return res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.EMPTY_NAME));
+    res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.EMPTY_NAME));
+    return;
   }
 
   if (!isValidUrl(companyPostData.companyUrl)) {
-    return res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.INVALID_URL));
+    res.status(HTTP_STATUS_BAD_REQUEST).json(errorMessages.get(ErrorType.INVALID_URL));
+    return;
   }
 
   const newCompany = await prisma.company.create({

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -21,15 +21,15 @@ enum MessageType {
 const prisma = new PrismaClient();
 
 const messages = Object.freeze({
+  [MessageType.EMPTY_NAME]: { type: StatusMessageType.ERROR, message: 'Company name is empty.' },
+  [MessageType.INVALID_COMPANY_URL]: { type: StatusMessageType.ERROR, message: 'Company url is invalid.' },
+  [MessageType.MISSING_NAME]: { type: StatusMessageType.ERROR, message: 'Company name is missing.' },
+  [MessageType.MISSING_COMPANY_URL]: { type: StatusMessageType.ERROR, message: 'Company url is missing.' },
   [MessageType.COMPANY_ALREADY_EXISTS]: { type: StatusMessageType.SUCCESS, message: 'Company already exists.' },
   [MessageType.COMPANY_CREATED_SUCCESSFULLY]: {
     type: StatusMessageType.SUCCESS,
     message: 'Company created successfully.',
   },
-  [MessageType.EMPTY_NAME]: { type: StatusMessageType.ERROR, message: 'Company name is empty.' },
-  [MessageType.INVALID_COMPANY_URL]: { type: StatusMessageType.ERROR, message: 'Company url is invalid.' },
-  [MessageType.MISSING_NAME]: { type: StatusMessageType.ERROR, message: 'Company name is missing.' },
-  [MessageType.MISSING_COMPANY_URL]: { type: StatusMessageType.ERROR, message: 'Company url is missing.' },
 });
 
 function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { CompanyData, CompanyListData, CompanyPostData } from '../../types/company';
 import { isEmpty, isValidUrl } from '../../utils/strings/validations';
-import {capitalizeEveryWord, removeProtocolAndWwwIfPresent, trim} from '../../utils/strings/formatters';
+import { capitalizeEveryWord, removeProtocolAndWwwIfPresent, trim } from '../../utils/strings/formatters';
 import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '../../utils/http/httpHelpers';
 import { withAuth } from '../../utils/auth/jwtHelpers';
 import { ApiResponse, StatusMessageType } from '../../types/apiResponse';
@@ -14,8 +14,9 @@ enum MessageType {
   COMPANY_CREATED_SUCCESSFULLY,
   EMPTY_NAME,
   INVALID_COMPANY_URL,
-  MISSING_NAME,
+  INVALID_NAME,
   MISSING_COMPANY_URL,
+  MISSING_NAME,
 }
 
 const prisma = new PrismaClient();
@@ -23,6 +24,7 @@ const prisma = new PrismaClient();
 const messages = Object.freeze({
   [MessageType.EMPTY_NAME]: { type: StatusMessageType.ERROR, message: 'Company name is empty.' },
   [MessageType.INVALID_COMPANY_URL]: { type: StatusMessageType.ERROR, message: 'Company url is invalid.' },
+  [MessageType.INVALID_NAME]: { type: StatusMessageType.ERROR, message: 'Company name is invalid.' },
   [MessageType.MISSING_NAME]: { type: StatusMessageType.ERROR, message: 'Company name is missing.' },
   [MessageType.MISSING_COMPANY_URL]: { type: StatusMessageType.ERROR, message: 'Company url is missing.' },
   [MessageType.COMPANY_ALREADY_EXISTS]: { type: StatusMessageType.SUCCESS, message: 'Company already exists.' },
@@ -112,19 +114,23 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse<ApiResponse<
 }
 
 function validateRequest(req: NextApiRequest): Nullable<MessageType> {
-  if (!req.body.name) {
+  if (req.body.name === undefined) {
     return MessageType.MISSING_NAME;
+  }
+
+  if (req.body.name === null) {
+    return MessageType.INVALID_NAME;
   }
 
   if (isEmpty(req.body.name)) {
     return MessageType.EMPTY_NAME;
   }
 
-  if (!req.body.companyUrl) {
+  if (req.body.companyUrl === undefined) {
     return MessageType.MISSING_COMPANY_URL;
   }
 
-  if (!isValidUrl(req.body.companyUrl)) {
+  if (req.body.companyUrl === null || !isValidUrl(req.body.companyUrl)) {
     return MessageType.INVALID_COMPANY_URL;
   }
 

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -48,20 +48,24 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<CompanyListData[]>>) {
-  if (req.body.searchKeyword === undefined || req.body.searchKeyword === null) {
+  const { nameKeyword } = req.query;
+  const trimmedNameKeyword = nameKeyword && nameKeyword.toString().trim();
+
+  if (!trimmedNameKeyword) {
     res.status(HttpStatus.OK).json(createJsonResponse([]));
     return;
   }
-
-  const searchKeyword = req.body.searchKeyword.trim();
 
   const companies: CompanyListData[] = await prisma.company.findMany({
     where: {
       isVerified: true,
       name: {
-        contains: searchKeyword,
+        contains: trimmedNameKeyword,
         mode: 'insensitive',
       },
+    },
+    orderBy: {
+      name: 'asc',
     },
     select: { id: true, name: true, companyUrl: true },
   });

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -7,6 +7,7 @@ import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '..
 import { withAuth } from '../../utils/auth/jwtHelpers';
 import { ApiResponse, StatusMessageType } from '../../types/apiResponse';
 import { Nullable } from '../../types/utils';
+import { withPrismaErrorHandling } from '../../utils/prisma/prismaHelpers';
 
 enum MessageType {
   COMPANY_ALREADY_EXISTS,
@@ -126,4 +127,4 @@ function validateRequest(req: NextApiRequest): Nullable<MessageType> {
   return null;
 }
 
-export default withAuth(handler);
+export default withPrismaErrorHandling(withAuth(handler));

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -47,8 +47,21 @@ function handler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<CompanyListData[]>>) {
+  if (req.body.searchKeyword === undefined || req.body.searchKeyword === null) {
+    res.status(HttpStatus.OK).json(createJsonResponse([]));
+    return;
+  }
+
+  const searchKeyword = req.body.searchKeyword.trim();
+
   const companies: CompanyListData[] = await prisma.company.findMany({
-    where: { isVerified: true },
+    where: {
+      isVerified: true,
+      name: {
+        contains: searchKeyword,
+        mode: 'insensitive',
+      },
+    },
     select: { id: true, name: true, companyUrl: true },
   });
 

--- a/prisma/migrations/20220909144321_add_unique_index_for_company_name_and_company_url/migration.sql
+++ b/prisma/migrations/20220909144321_add_unique_index_for_company_name_and_company_url/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name,company_url]` on the table `companies` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "companies_name_company_url_key" ON "companies"("name", "company_url");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model Company {
 
   roles Role[]
 
+  @@unique([name, companyUrl])
   @@map("companies")
 }
 

--- a/types/company.ts
+++ b/types/company.ts
@@ -1,4 +1,4 @@
-export type CompanyData = {
+export type CompanyListData = {
   id: number;
   name: string;
   companyUrl: string;
@@ -8,3 +8,5 @@ export type CompanyPostData = {
   name: string;
   companyUrl: string;
 };
+
+export type CompanyData = CompanyListData;

--- a/types/company.ts
+++ b/types/company.ts
@@ -3,3 +3,8 @@ export type CompanyData = {
   name: string;
   companyUrl: string;
 };
+
+export type CompanyPostData = {
+  name: string;
+  companyUrl: string;
+};

--- a/types/error.ts
+++ b/types/error.ts
@@ -1,0 +1,3 @@
+export type ErrorData = {
+  message: string;
+};

--- a/types/error.ts
+++ b/types/error.ts
@@ -1,3 +1,0 @@
-export type ErrorData = {
-  message: string;
-};

--- a/utils/strings/formatters.ts
+++ b/utils/strings/formatters.ts
@@ -28,3 +28,7 @@ export function capitalizeEveryWord(phrase: string) {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
 }
+
+export function trim(value: string | string[]) {
+  return value.toString().trim();
+}

--- a/utils/strings/formatters.ts
+++ b/utils/strings/formatters.ts
@@ -1,0 +1,21 @@
+export function removeProtocolAndWwwIfPresent(url: string) {
+  const httpProtocolPrefix = 'http://';
+  const httpsProtocolPrefix = 'https://';
+  const wwwPrefix = 'www.';
+
+  let trimmedUrl = url;
+
+  if (trimmedUrl.startsWith(httpProtocolPrefix)) {
+    trimmedUrl = trimmedUrl.slice(httpProtocolPrefix.length);
+  }
+
+  if (trimmedUrl.startsWith(httpsProtocolPrefix)) {
+    trimmedUrl = trimmedUrl.slice(httpsProtocolPrefix.length);
+  }
+
+  if (trimmedUrl.startsWith(wwwPrefix)) {
+    trimmedUrl = trimmedUrl.slice(wwwPrefix.length);
+  }
+
+  return trimmedUrl;
+}

--- a/utils/strings/formatters.ts
+++ b/utils/strings/formatters.ts
@@ -19,3 +19,11 @@ export function removeProtocolAndWwwIfPresent(url: string) {
 
   return trimmedUrl;
 }
+
+export function capitalizeEveryWord(phrase: string) {
+  return phrase
+    .toLowerCase()
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/utils/strings/formatters.ts
+++ b/utils/strings/formatters.ts
@@ -21,6 +21,7 @@ export function removeProtocolAndWwwIfPresent(url: string) {
 }
 
 export function capitalizeEveryWord(phrase: string) {
+  // Safely handles words with length 0 or 1 as well.
   return phrase
     .toLowerCase()
     .split(' ')

--- a/utils/strings/validations.ts
+++ b/utils/strings/validations.ts
@@ -2,7 +2,7 @@ export function isEmpty(value: string) {
   return !value.trim();
 }
 
-// Note: This denotes an url as valid even without a protocol or domain.
+// Note: This denotes a url as valid even without a protocol or domain.
 export function isValidUrl(value: string) {
   const patternWithProtocol = new RegExp(
     '^(http[s]?:\\/\\/(www\\.)?|ftp:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?',

--- a/utils/strings/validations.ts
+++ b/utils/strings/validations.ts
@@ -5,10 +5,10 @@ export function isEmpty(value: string) {
 // Note: This denotes a url as valid even without a protocol or domain.
 export function isValidUrl(value: string) {
   const patternWithProtocol = new RegExp(
-    '^(http[s]?:\\/\\/(www\\.)?|ftp:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,})+)/?(?:\\s|$)',
+    '^(http[s]?:\\/\\/(www\\.)?|ftp:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,})+)(/(.)*)?(\\\\?(.)*)?',
   );
 
-  const patternWithoutProtocol = new RegExp('^([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,})+)/?(?:\\s|$)');
+  const patternWithoutProtocol = new RegExp('^([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,})+)(/(.)*)?(\\\\?(.)*)?');
 
   return patternWithProtocol.test(value) || patternWithoutProtocol.test(value);
 }

--- a/utils/strings/validations.ts
+++ b/utils/strings/validations.ts
@@ -5,10 +5,10 @@ export function isEmpty(value: string) {
 // Note: This denotes a url as valid even without a protocol or domain.
 export function isValidUrl(value: string) {
   const patternWithProtocol = new RegExp(
-    '^(http[s]?:\\/\\/(www\\.)?|ftp:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?',
+    '^(http[s]?:\\/\\/(www\\.)?|ftp:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,})+)/?(?:\\s|$)',
   );
 
-  const patternWithoutProtocol = new RegExp('^([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?');
+  const patternWithoutProtocol = new RegExp('^([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,})+)/?(?:\\s|$)');
 
   return patternWithProtocol.test(value) || patternWithoutProtocol.test(value);
 }

--- a/utils/strings/validations.ts
+++ b/utils/strings/validations.ts
@@ -1,3 +1,14 @@
 export function isEmpty(value: string) {
   return !value.trim();
 }
+
+// Note: This denotes an url as valid even without a protocol or domain.
+export function isValidUrl(value: string) {
+  const patternWithProtocol = new RegExp(
+    '^(http[s]?:\\/\\/(www\\.)?|ftp:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?',
+  );
+
+  const patternWithoutProtocol = new RegExp('^([0-9A-Za-z-\\.@:%_+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?');
+
+  return patternWithProtocol.test(value) || patternWithoutProtocol.test(value);
+}


### PR DESCRIPTION
Handlers
- POST
  - Company (name, companyUrl).
  - companyUrl will be trimmed to remove protocol and www if present.
- GET
  - List of companies that are verified
  - Will only return companies whose names contain the search keyword, case insensitive. If the search keyword is not provided, it returns nothing.

Utils
- String formatters and validations

Database
- Added unique index for Company(name, companyUrl), **please drop db if necessary and regenerate with `yarn prisma migrate dev`**