### PR TITLE
Add stage api

### DIFF
--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -185,14 +185,14 @@ function validatePatchRequest(req: NextApiRequest) {
     return MessageType.INVALID_APPLICATION_STAGE_TYPE;
   }
 
-  if (req.body.date !== undefined && !isValidDate(req.body.date)) {
+  if (req.body.date !== undefined && (typeof req.body.date !== 'string' || !isValidDate(req.body.date))) {
     return MessageType.INVALID_DATE;
   }
 
   if (
     req.body.emojiUnicodeHex !== undefined &&
     req.body.emojiUnicodeHex !== null &&
-    !isValidHex(req.body.emojiUnicodeHex)
+    (typeof req.body.emojiUnicodeHex !== 'string' || !isValidHex(req.body.emojiUnicodeHex))
   ) {
     return MessageType.INVALID_EMOJI_UNICODE_HEX;
   }

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -39,10 +39,6 @@ const messages = Object.freeze({
     type: StatusMessageType.ERROR,
     message: 'Application stage cannot be found.',
   },
-  [MessageType.EMPTY_UPDATE]: {
-    type: StatusMessageType.ERROR,
-    message: 'At least one field must be provided for an update.',
-  },
   [MessageType.APPLICATION_STAGE_UPDATE_UNAUTHORIZED]: {
     type: StatusMessageType.ERROR,
     message: 'Application stage cannot be updated by the user.',
@@ -179,10 +175,6 @@ function validatePatchRequest(req: NextApiRequest) {
 
   if (!isInteger(req.query.applicationId as string)) {
     return MessageType.INVALID_APPLICATION_ID;
-  }
-
-  if (!req.body || Object.keys(req.body).length == 0) {
-    return MessageType.EMPTY_UPDATE;
   }
 
   if (req.body.type !== undefined && !(req.body.type in ApplicationStageType)) {

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -16,6 +16,7 @@ enum MessageType {
   APPLICATION_STAGE_NOT_FOUND,
   APPLICATION_STAGE_UPDATE_UNAUTHORIZED,
   APPLICATION_STAGE_UPDATED_SUCCESSFULLY,
+  EMPTY_UPDATE,
   INVALID_APPLICATION_ID,
   INVALID_APPLICATION_STAGE_ID,
   INVALID_APPLICATION_STAGE_TYPE,
@@ -37,6 +38,10 @@ const messages = Object.freeze({
   [MessageType.APPLICATION_STAGE_NOT_FOUND]: {
     type: StatusMessageType.ERROR,
     message: 'Application stage cannot be found.',
+  },
+  [MessageType.EMPTY_UPDATE]: {
+    type: StatusMessageType.ERROR,
+    message: 'At least one field must be provided for an update.',
   },
   [MessageType.APPLICATION_STAGE_UPDATE_UNAUTHORIZED]: {
     type: StatusMessageType.ERROR,
@@ -181,6 +186,10 @@ function validatePatchRequest(req: NextApiRequest) {
 
   if (!isInteger(req.query.applicationId as string)) {
     return MessageType.INVALID_APPLICATION_ID;
+  }
+
+  if (!req.body || Object.keys(req.body).length == 0) {
+    return MessageType.EMPTY_UPDATE;
   }
 
   if (req.body.type !== undefined && !(req.body.type in ApplicationStageType)) {

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -171,7 +171,7 @@ async function handleDelete(userId: string, req: NextApiRequest, res: NextApiRes
 }
 
 function validatePatchRequest(req: NextApiRequest) {
-  if (!isInteger(req.query.applicationStageId as string)) {
+  if (!isInteger(req.query.stageId as string)) {
     return MessageType.INVALID_APPLICATION_STAGE_ID;
   }
 
@@ -199,7 +199,7 @@ function validatePatchRequest(req: NextApiRequest) {
 }
 
 function validateDeleteRequest(req: NextApiRequest) {
-  if (!isInteger(req.query.applicationStageId as string)) {
+  if (!isInteger(req.query.stageId as string)) {
     return MessageType.INVALID_APPLICATION_STAGE_ID;
   }
 

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -1,5 +1,105 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { ApplicationStageType, PrismaClient } from '@prisma/client';
+import { ApplicationStagePatchData } from '../../../../../types/applicationStage';
+import { ErrorData } from '../../../../../types/error';
+import { isValidHex } from '../../../../../utils/strings/validations';
+import { withAuthUser } from '../../../../../utils/auth/jwtHelpers';
+import { isValidDate } from '../../../../../utils/date/validations';
+import { HttpMethod, HttpStatus, rejectHttpMethod } from '../../../../../utils/http/httpHelpers';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).end(`Request sent to ${req.url}\n`);
+enum ErrorType {
+  INVALID_APPLICATION_STAGE_TYPE,
+  INVALID_DATE,
+  INVALID_EMOJI_UNICODE_HEX,
 }
+
+const prisma = new PrismaClient();
+
+const errorMessages = new Map<ErrorType, ErrorData>([
+  [ErrorType.INVALID_APPLICATION_STAGE_TYPE, { message: 'Application stage type is invalid.' }],
+  [ErrorType.INVALID_DATE, { message: 'Date is invalid.' }],
+  [ErrorType.INVALID_EMOJI_UNICODE_HEX, { message: 'Emoji unicode hex is invalid.' }],
+]);
+
+function handler(userId: string, req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method;
+  switch (method) {
+    case HttpMethod.PATCH:
+      handlePatch(userId, req, res);
+      break;
+    default:
+      rejectHttpMethod(res, method);
+  }
+}
+
+async function handlePatch(userId: string, req: NextApiRequest, res: NextApiResponse) {
+  validateRequest(req, res);
+
+  const applicationStageId = Number(req.query.stageId);
+
+  const applicationStagePatchData: ApplicationStagePatchData = {
+    ...req.body,
+    date: new Date(req.body.date),
+  };
+
+  // Note: updateMany is used to allow filter on non-unique columns.
+  // This allows a check to ensure users are only editing their own application stages.
+  const updatedData = await prisma.applicationStage.updateMany({
+    where: {
+      id: applicationStageId,
+      application: {
+        userId: userId,
+      },
+    },
+    data: {
+      type: applicationStagePatchData.type,
+      date: applicationStagePatchData.date,
+      emojiUnicodeHex: applicationStagePatchData.emojiUnicodeHex,
+      remark: applicationStagePatchData.remark,
+    },
+  });
+
+  if (updatedData.count < 1) {
+    res.status(HttpStatus.BAD_REQUEST).end();
+    return;
+  }
+
+  const updatedApplicationStage = await prisma.applicationStage.findUnique({
+    where: {
+      id: applicationStageId,
+    },
+    select: {
+      id: true,
+      applicationId: true,
+      type: true,
+      date: true,
+      emojiUnicodeHex: true,
+      remark: true,
+    },
+  });
+
+  res.status(HttpStatus.OK).json(updatedApplicationStage);
+}
+
+function validateRequest(req: NextApiRequest, res: NextApiResponse) {
+  if (req.body.type !== undefined && !Object.values(ApplicationStageType).includes(req.body.type)) {
+    res.status(HttpStatus.BAD_REQUEST).json(errorMessages.get(ErrorType.INVALID_APPLICATION_STAGE_TYPE));
+    return;
+  }
+
+  if (req.body.date !== undefined && !isValidDate(req.body.date)) {
+    res.status(HttpStatus.BAD_REQUEST).json(errorMessages.get(ErrorType.INVALID_DATE));
+    return;
+  }
+
+  if (
+    req.body.emojiUnicodeHex !== undefined &&
+    req.body.emojiUnicodeHex !== null &&
+    !isValidHex(req.body.emojiUnicodeHex)
+  ) {
+    res.status(HttpStatus.BAD_REQUEST).json(errorMessages.get(ErrorType.INVALID_EMOJI_UNICODE_HEX));
+    return;
+  }
+}
+
+export default withAuthUser(handler);

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -150,6 +150,8 @@ async function handleDelete(userId: string, req: NextApiRequest, res: NextApiRes
   const applicationStageId = Number(req.query.stageId);
   const applicationId = Number(req.query.applicationId);
 
+  // Note: deleteMany is used to allow filter on non-unique columns.
+  // This allows a check to ensure users are only deleting their own application stages.
   const { count } = await prisma.applicationStage.deleteMany({
     where: {
       id: applicationStageId,

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -39,6 +39,7 @@ async function handlePatch(userId: string, req: NextApiRequest, res: NextApiResp
   validateRequest(req, res);
 
   const applicationStageId = Number(req.query.stageId);
+  const applicationId = Number(req.query.applicationId);
 
   const applicationStagePatchData: ApplicationStagePatchData = {
     ...req.body,
@@ -51,6 +52,7 @@ async function handlePatch(userId: string, req: NextApiRequest, res: NextApiResp
     where: {
       id: applicationStageId,
       application: {
+        id: applicationId,
         userId: userId,
       },
     },
@@ -86,11 +88,13 @@ async function handlePatch(userId: string, req: NextApiRequest, res: NextApiResp
 
 async function handleDelete(userId: string, req: NextApiRequest, res: NextApiResponse) {
   const applicationStageId = Number(req.query.stageId);
+  const applicationId = Number(req.query.applicationId);
 
   const { count } = await prisma.applicationStage.deleteMany({
     where: {
       id: applicationStageId,
       application: {
+        id: applicationId,
         userId: userId,
       },
     },

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -85,7 +85,7 @@ async function handlePatch(
   res: NextApiResponse<ApiResponse<ApplicationStageData>>,
 ) {
   const errorMessageType = validatePatchRequest(req);
-  if (errorMessageType != null) {
+  if (errorMessageType !== null) {
     res.status(HttpStatus.BAD_REQUEST).json(createJsonResponse({}, messages[errorMessageType]));
     return;
   }
@@ -94,8 +94,10 @@ async function handlePatch(
   const applicationId = Number(req.query.applicationId);
 
   const applicationStagePatchData: ApplicationStagePatchData = {
-    ...req.body,
+    type: req.body.type,
     date: new Date(req.body.date),
+    emojiUnicodeHex: req.body.emojiUnicodeHex,
+    remark: req.body.remark,
   };
 
   // Note: updateMany is used to allow filter on non-unique columns.
@@ -181,7 +183,7 @@ function validatePatchRequest(req: NextApiRequest) {
     return MessageType.INVALID_APPLICATION_ID;
   }
 
-  if (req.body.type !== undefined && !Object.values(ApplicationStageType).includes(req.body.type)) {
+  if (req.body.type !== undefined && !(req.body.type in ApplicationStageType)) {
     return MessageType.INVALID_APPLICATION_STAGE_TYPE;
   }
 

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -98,12 +98,7 @@ async function handlePatch(
   const applicationStageId = Number(req.query.stageId);
   const applicationId = Number(req.query.applicationId);
 
-  const applicationStagePatchData: ApplicationStagePatchData = {
-    type: req.body.type,
-    date: new Date(req.body.date),
-    emojiUnicodeHex: req.body.emojiUnicodeHex,
-    remark: req.body.remark,
-  };
+  const applicationStagePatchData: ApplicationStagePatchData = makePatchData(req);
 
   // Note: updateMany is used to allow filter on non-unique columns.
   // This allows a check to ensure users are only updating their own application stages.
@@ -209,6 +204,28 @@ function validatePatchRequest(req: NextApiRequest) {
   }
 
   return null;
+}
+
+function makePatchData(req: NextApiRequest) {
+  const applicationStagePatchData: ApplicationStagePatchData = {};
+
+  if (req.body.type !== undefined) {
+    applicationStagePatchData.type = req.body.type;
+  }
+
+  if (req.body.date !== undefined) {
+    applicationStagePatchData.date = new Date(req.body.date);
+  }
+
+  if (req.body.emojiUnicodeHex !== undefined) {
+    applicationStagePatchData.emojiUnicodeHex = req.body.emojiUnicodeHex;
+  }
+
+  if (req.body.remark !== undefined) {
+    applicationStagePatchData.remark = req.body.remark;
+  }
+
+  return applicationStagePatchData;
 }
 
 function validateDeleteRequest(req: NextApiRequest) {

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -6,6 +6,7 @@ import { isValidHex } from '../../../../../utils/strings/validations';
 import { withAuthUser } from '../../../../../utils/auth/jwtHelpers';
 import { isValidDate } from '../../../../../utils/date/validations';
 import { HttpMethod, HttpStatus, rejectHttpMethod } from '../../../../../utils/http/httpHelpers';
+import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';
 
 enum ErrorType {
   INVALID_APPLICATION_STAGE_TYPE,
@@ -129,4 +130,4 @@ function validateRequest(req: NextApiRequest, res: NextApiResponse) {
   }
 }
 
-export default withAuthUser(handler);
+export default withPrismaErrorHandling(withAuthUser(handler));

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -70,17 +70,15 @@ const messages = Object.freeze({
   },
 });
 
-function handler(userId: string, req: NextApiRequest, res: NextApiResponse) {
+async function handler(userId: string, req: NextApiRequest, res: NextApiResponse) {
   const method = req.method;
   switch (method) {
     case HttpMethod.PATCH:
-      handlePatch(userId, req, res);
-      break;
+      return handlePatch(userId, req, res);
     case HttpMethod.DELETE:
-      handleDelete(userId, req, res);
-      break;
+      return handleDelete(userId, req, res);
     default:
-      rejectHttpMethod(res, method);
+      return rejectHttpMethod(res, method);
   }
 }
 

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -76,7 +76,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<C
 }
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse<ApiResponse<CompanyData>>) {
-  const errorMessageType = validateRequest(req);
+  const errorMessageType = validatePostRequest(req);
   if (errorMessageType !== null) {
     res.status(HttpStatus.BAD_REQUEST).json(createJsonResponse({}, messages[errorMessageType]));
     return;
@@ -113,7 +113,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse<ApiResponse<
     .json(createJsonResponse(newCompany, messages[MessageType.COMPANY_CREATED_SUCCESSFULLY]));
 }
 
-function validateRequest(req: NextApiRequest): Nullable<MessageType> {
+function validatePostRequest(req: NextApiRequest): Nullable<MessageType> {
   if (req.body.name === undefined) {
     return MessageType.MISSING_NAME;
   }

--- a/pages/api/companies.ts
+++ b/pages/api/companies.ts
@@ -118,7 +118,7 @@ function validatePostRequest(req: NextApiRequest): Nullable<MessageType> {
     return MessageType.MISSING_NAME;
   }
 
-  if (req.body.name === null) {
+  if (req.body.name === null || typeof req.body.name !== 'string') {
     return MessageType.INVALID_NAME;
   }
 
@@ -130,7 +130,7 @@ function validatePostRequest(req: NextApiRequest): Nullable<MessageType> {
     return MessageType.MISSING_COMPANY_URL;
   }
 
-  if (req.body.companyUrl === null || !isValidUrl(req.body.companyUrl)) {
+  if (req.body.companyUrl === null || typeof req.body.companyUrl !== 'string' || !isValidUrl(req.body.companyUrl)) {
     return MessageType.INVALID_COMPANY_URL;
   }
 

--- a/types/application.ts
+++ b/types/application.ts
@@ -1,4 +1,4 @@
-import { ApplicationStageData } from './applicationStage';
+import { ApplicationStageApplicationData } from './applicationStage';
 import { CompanyData } from './company';
 import { RoleData } from './role';
 import { TaskData } from './task';
@@ -6,6 +6,6 @@ import { TaskData } from './task';
 export type ApplicationData = {
   id: number;
   role: RoleData & { company: CompanyData };
-  applicationStages: ApplicationStageData[];
+  applicationStages: ApplicationStageApplicationData[];
   tasks: TaskData[];
 };

--- a/types/applicationStage.ts
+++ b/types/applicationStage.ts
@@ -12,8 +12,8 @@ export type ApplicationStageApplicationData = {
 export type ApplicationStageData = ApplicationStageApplicationData & { applicationId: number };
 
 export type ApplicationStagePatchData = {
-  type: ApplicationStageType;
-  date: Date;
-  emojiUnicodeHex: string | null;
-  remark: string | null;
+  type?: ApplicationStageType;
+  date?: Date;
+  emojiUnicodeHex?: Nullable<string>;
+  remark?: Nullable<string>;
 };

--- a/types/applicationStage.ts
+++ b/types/applicationStage.ts
@@ -8,3 +8,10 @@ export type ApplicationStageData = {
   emojiUnicodeHex: Nullable<string>;
   remark: Nullable<string>;
 };
+
+export type ApplicationStagePatchData = {
+  type: ApplicationStageType;
+  date: Date;
+  emojiUnicodeHex: string | null;
+  remark: string | null;
+};

--- a/types/applicationStage.ts
+++ b/types/applicationStage.ts
@@ -1,13 +1,15 @@
 import { ApplicationStageType } from '@prisma/client';
 import { Nullable } from './utils';
 
-export type ApplicationStageData = {
+export type ApplicationStageApplicationData = {
   id: number;
   type: ApplicationStageType;
   date: Date;
   emojiUnicodeHex: Nullable<string>;
   remark: Nullable<string>;
 };
+
+export type ApplicationStageData = ApplicationStageApplicationData & { applicationId: number };
 
 export type ApplicationStagePatchData = {
   type: ApplicationStageType;

--- a/types/error.ts
+++ b/types/error.ts
@@ -1,0 +1,3 @@
+export type ErrorData = {
+  message: string;
+};

--- a/types/error.ts
+++ b/types/error.ts
@@ -1,3 +1,0 @@
-export type ErrorData = {
-  message: string;
-};

--- a/utils/strings/validations.ts
+++ b/utils/strings/validations.ts
@@ -12,3 +12,8 @@ export function isValidUrl(value: string) {
 
   return patternWithProtocol.test(value) || patternWithoutProtocol.test(value);
 }
+
+export function isValidHex(value: string) {
+  const number = parseInt(value, 16);
+  return number.toString(16) === value.toLowerCase();
+}


### PR DESCRIPTION
Handlers
- PATCH
  - Any of {type, date, emojiUnicodeHex, remark}.
  - Request body fields must be validated otherwise there could be runtime errors when converting from string to date etc.
- DELETE

Some changes to previous standards

- Changed `validateRequest` to `validateMethodRequest` because different methods of the same endpoint can have different validations
- Decided to use `XX_METHOD_UNAUTHORIZED` as `MessageType` and similarly for the message, instead of saying it does not belong to user because `belonging to the user !== authorized`
- Moved validation of query prams into `validateMethodRequest` function