### PR TITLE
Ensure that middleware doesn't break promise contract.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ yarn.lock
 *.svg
 prisma/migrations/
 prisma/schema.prisma
+coverage/

--- a/utils/auth/jwtHelpers.ts
+++ b/utils/auth/jwtHelpers.ts
@@ -46,7 +46,7 @@ export function withAuthUser<D>(
         .json(createJsonResponse({}, { type: StatusMessageType.ERROR, message: UNABLE_TO_AUTHENTICATE }));
     }
 
-    return handler(userDetails.uid, req, res);
+    return await Promise.resolve(handler(userDetails.uid, req, res));
   };
 }
 
@@ -79,7 +79,7 @@ export function withVerifiedUser<D>(
         .json(createJsonResponse({}, { type: StatusMessageType.ERROR, message: USER_NOT_AUTHORIZED }));
     }
 
-    return handler(uid, req, res);
+    return await Promise.resolve(handler(uid, req, res));
   };
 }
 

--- a/utils/prisma/prismaHelpers.ts
+++ b/utils/prisma/prismaHelpers.ts
@@ -32,9 +32,9 @@ type PrismaErrors =
   | PrismaClientValidationError;
 
 export function withPrismaErrorHandling<D>(handler: NextApiHandler<ApiResponse<D>>): NextApiHandler<ApiResponse<D>> {
-  return (req, res) => {
+  return async (req, res) => {
     try {
-      handler(req, res);
+      await Promise.resolve(handler(req, res));
     } catch (err) {
       // Could be a PrismaError, Error or something that does not conform to the interface.
       // eslint-disable-next-line


### PR DESCRIPTION
There was an issue earlier where middleware wasn't returning promises that were chained after the handler. This could result in serious bugs down the road (during serverless), but its fixed now.
