### PR TITLE
Account for Prisma error codes that should result in bad params.

### DIFF
--- a/utils/prisma/prismaHelpers.ts
+++ b/utils/prisma/prismaHelpers.ts
@@ -18,6 +18,25 @@ const BAD_DATA_PRISMA_ERROR_MESSAGE = {
   type: StatusMessageType.ERROR,
   message: 'The data provided to the server does not match the requirements. Please check your parameters',
 };
+const BAD_INPUT_PRISMA_ERROR_CODES = [
+  'P2000',
+  'P2005',
+  'P2006',
+  'P2008',
+  'P2009',
+  'P2010',
+  'P2012',
+  'P2011',
+  'P2013',
+  'P2016',
+  'P2019',
+  'P2020',
+  'P2033',
+];
+const BAD_INPUT_PRISMA_ERROR_MESSAGE = {
+  type: StatusMessageType.ERROR,
+  message: 'The data used is not in the form expected by the server.',
+};
 const RETRYABLE_PRISMA_ERROR_CODES = ['P1002', 'P1008', 'P1011', 'P1017'];
 const RETRYABLE_PRISMA_ERROR_MESSAGE = {
   type: StatusMessageType.ERROR,
@@ -41,10 +60,15 @@ export function withPrismaErrorHandling<D>(handler: NextApiHandler<ApiResponse<D
       const error: PrismaErrors | Error = err as any;
       if (error instanceof PrismaClientKnownRequestError) {
         console.error(`${error.name}: ${error.code}, ${error.message}, ${error.meta}`);
-        if (error.code in RETRYABLE_PRISMA_ERROR_CODES) {
+
+        if (RETRYABLE_PRISMA_ERROR_CODES.includes(error.code)) {
           return res
             .status(HttpStatus.SERVICE_UNAVAILABLE)
             .json(createJsonResponse({}, RETRYABLE_PRISMA_ERROR_MESSAGE));
+        }
+
+        if (BAD_INPUT_PRISMA_ERROR_CODES.includes(error.code)) {
+          return res.status(HttpStatus.BAD_REQUEST).json(createJsonResponse({}, BAD_INPUT_PRISMA_ERROR_MESSAGE));
         }
 
         return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json(createJsonResponse({}, UNSOLVABLE_ERROR_MESSAGE));
@@ -56,7 +80,7 @@ export function withPrismaErrorHandling<D>(handler: NextApiHandler<ApiResponse<D
         return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json(createJsonResponse({}, UNSOLVABLE_ERROR_MESSAGE));
       } else if (error instanceof PrismaClientInitializationError) {
         console.error(`${error.name}: ${error.errorCode}, ${error.message}`);
-        if (error.errorCode && error.errorCode in RETRYABLE_PRISMA_ERROR_CODES) {
+        if (error.errorCode && RETRYABLE_PRISMA_ERROR_CODES.includes(error.errorCode)) {
           return res
             .status(HttpStatus.SERVICE_UNAVAILABLE)
             .json(createJsonResponse({}, RETRYABLE_PRISMA_ERROR_MESSAGE));


### PR DESCRIPTION
Also I hadn't realised that includes isn't the same as in. There was a bug where error codes were always ignored.