### PR TITLE
Add Jest test cases for /user api & prisma.

### DIFF
--- a/__tests__/pages/api/user/index.test.ts
+++ b/__tests__/pages/api/user/index.test.ts
@@ -1,0 +1,154 @@
+import { createMocks, getPrismaClientForTests, prismaMigrateReset } from '../util.test';
+import userHandler from '../../../../pages/api/user/index';
+import { HttpMethod, HttpStatus } from '../../../../utils/http/httpHelpers';
+
+const KNOWN_ROLE_ID = 1;
+const createUserMocks = (uid: string, method: HttpMethod, oldToken?: string) =>
+  createMocks(userHandler, { uid, method, body: { oldToken } });
+
+describe('DELETE accounts', () => {
+  const createUserDeleteMocks = (uid: string) => createUserMocks(uid, HttpMethod.DELETE);
+  const prisma = getPrismaClientForTests();
+
+  beforeAll(prismaMigrateReset);
+
+  it('delete accounts with no data', async () => {
+    const uid = 'devUserWithoutData';
+    const { req, res, getResult } = createUserDeleteMocks(uid);
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(1);
+
+    await userHandler(req, res);
+    const { status, json } = getResult();
+
+    expect(status).toEqual(HttpStatus.OK);
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(0);
+    expect(json.payload).toEqual({});
+  });
+
+  it('delete accounts with data', async () => {
+    const uid = 'devUserWithData';
+    const { req, res, getResult } = createUserDeleteMocks(uid);
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(1);
+
+    await userHandler(req, res);
+    const { status, json } = getResult();
+
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(0);
+    expect(status).toEqual(HttpStatus.OK);
+    expect(json.payload).toEqual({});
+  });
+
+  it('cannot delete missing accounts', async () => {
+    const uid = 'devUserDoesNotExistInDatabase';
+    const { req, res, getResult } = createUserDeleteMocks(uid);
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(0);
+
+    await userHandler(req, res);
+    const { status, json } = getResult();
+
+    expect(status).toEqual(HttpStatus.NOT_FOUND);
+  });
+});
+
+describe('POST accounts without linking', () => {
+  const createUserPostMocks = (uid: string) => createUserMocks(uid, HttpMethod.POST);
+  const prisma = getPrismaClientForTests();
+
+  beforeAll(prismaMigrateReset);
+
+  it('create new user', async () => {
+    const uid = 'devUserDoesNotExistP1';
+    const { req, res, getResult } = createUserPostMocks(uid);
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(0);
+
+    await userHandler(req, res);
+    const user = await prisma.user.findUnique({ where: { uid } });
+    const { status, json } = getResult();
+
+    expect(status).toEqual(HttpStatus.CREATED);
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(1);
+    expect(json.payload).toEqual({ uid });
+  });
+
+  it('fails to recreate existing user.', async () => {
+    const uid = 'devUserDoesNotExistP2';
+    await prisma.user.create({ data: { uid } });
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(1);
+    const { req, res, getResult } = createUserPostMocks(uid);
+
+    await userHandler(req, res);
+    const { status, json } = getResult();
+
+    expect(status).toEqual(HttpStatus.CONFLICT);
+    expect(await prisma.user.count({ where: { uid } })).toStrictEqual(1);
+    expect(json.payload).toEqual({});
+  });
+});
+
+describe('POST accounts with linking', () => {
+  const createLinkMocks = (oldUid: string, newUid: string) => createUserMocks(newUid, HttpMethod.POST, oldUid);
+  const prisma = getPrismaClientForTests();
+
+  beforeAll(prismaMigrateReset);
+
+  it('will link anon to verified.', async () => {
+    const oldUid = 'devUserFoo';
+    const newUid = 'devUserVerifiedBar';
+    await prisma.user.create({ data: { uid: oldUid } });
+    const { req, res, getResult } = createLinkMocks(oldUid, newUid);
+
+    await userHandler(req, res);
+    const { status, json } = getResult();
+
+    expect(status).toEqual(HttpStatus.OK);
+    expect(json.payload).toEqual({ uid: newUid });
+  });
+
+  it('will link anon to verified (does not exist) and transfer data.', async () => {
+    const oldUid = 'devUserWithDataBar';
+    const newUid = 'devUserVerifiedWithoutDataBar';
+    await prisma.user.create({ data: { uid: oldUid } });
+    const application = await prisma.application.create({ data: { userId: oldUid, roleId: KNOWN_ROLE_ID } });
+    expect(await prisma.user.count({ where: { uid: newUid } })).toStrictEqual(0);
+    const { req, res, getResult } = createLinkMocks(oldUid, newUid);
+
+    await userHandler(req, res);
+    const { status, json } = getResult();
+
+    expect(await prisma.user.count({ where: { uid: oldUid } })).toBe(0);
+    const newUser = await prisma.user.findUnique({ where: { uid: newUid }, include: { applications: true } });
+    expect(newUser?.applications.map((a) => a.id)).toStrictEqual([application.id]);
+    expect(status).toEqual(HttpStatus.OK);
+    expect(json.payload).toEqual({ uid: newUid });
+  });
+
+  it('will not link anon to existing verified.', async () => {
+    const oldUid = 'devUserWithDataFoo';
+    const newUid = 'devUserVerifiedWithoutDataFoo';
+    await prisma.user.create({ data: { uid: oldUid } });
+    await prisma.user.create({ data: { uid: newUid } });
+    const { req, res, getResult } = createLinkMocks(oldUid, newUid);
+
+    await userHandler(req, res);
+    const { status, json } = getResult();
+
+    expect(status).toEqual(HttpStatus.CONFLICT);
+    expect(json.payload).toEqual({});
+  });
+
+  function willFailToLinkExceptAnonToVerified(oldUid: string, newUid: string, expectedStatus: HttpStatus) {
+    it(`will fail to link ${oldUid} to ${newUid} as it is not anon to verified.`, async () => {
+      const { req, res, getResult } = createLinkMocks(oldUid, newUid);
+
+      await userHandler(req, res);
+      const { status, json } = getResult();
+
+      expect(status).toEqual(expectedStatus);
+      expect(json.payload).toEqual({});
+    });
+  }
+
+  willFailToLinkExceptAnonToVerified('devUserAnonFoo', 'devUserAnonBar', HttpStatus.UNAUTHORIZED);
+  willFailToLinkExceptAnonToVerified('devUserVerifiedFoo', 'devUserAnonBar', HttpStatus.UNAUTHORIZED);
+  willFailToLinkExceptAnonToVerified('devUserVerifiedFoo', 'devUserVerifiedFoo', HttpStatus.BAD_REQUEST);
+});

--- a/__tests__/pages/api/util.test.ts
+++ b/__tests__/pages/api/util.test.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from '@prisma/client';
+import { spawn, spawnSync } from 'child_process';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { cwd } from 'process';
 import { ApiResponse } from '../../../types/apiResponse';
 import { HttpMethod, HttpStatus } from '../../../utils/http/httpHelpers';
 
@@ -15,8 +17,21 @@ export function getPrismaClientForTests() {
   return prisma;
 }
 
+export function prismaMigrateReset() {
+  process.stdout.write('Resetting database.');
+
+  const command = 'yarn';
+  const args = ['prisma', 'migrate', 'reset', '--force'];
+  const options = {
+    shell: true,
+    cwd: cwd(),
+  };
+
+  spawnSync(command, args, options);
+}
+
 export function createMocks<D>(
-  _handler: (req: NextApiRequest, res: NextApiResponse<ApiResponse<D>>) => void,
+  handler: (req: NextApiRequest, res: NextApiResponse<ApiResponse<D>>) => void,
   // eslint-disable-next-line
   { uid, method, query, body }: { uid: string; method: HttpMethod; query?: Record<string, string>; body?: any },
 ) {

--- a/utils/auth/jwtHelpers.ts
+++ b/utils/auth/jwtHelpers.ts
@@ -104,7 +104,7 @@ export async function getUserFromJwt(token: string): Promise<UserDetailsFromRequ
   // If you are running this in development mode, JWT token verification and decoding can be skipped.
   // Use bearer token 'devUserFoo' to get { uid: 'devUserFoo', isAnonymous: true }
   // Use bearer token 'devUserVerifiedFoo' to get { uid: 'devUserVerifiedFoo', isAnonymous: false }
-  if (process.env.NODE_ENV == 'development' && /devUser/u.test(token)) {
+  if (['development', 'test'].includes(process.env.NODE_ENV) && /devUser/u.test(token)) {
     return { uid: token, isAnonymous: !/Verified/u.test(token) };
   }
 

--- a/utils/auth/jwtHelpers.ts
+++ b/utils/auth/jwtHelpers.ts
@@ -104,7 +104,7 @@ export async function getUserFromJwt(token: string): Promise<UserDetailsFromRequ
   // If you are running this in development mode, JWT token verification and decoding can be skipped.
   // Use bearer token 'devUserFoo' to get { uid: 'devUserFoo', isAnonymous: true }
   // Use bearer token 'devUserVerifiedFoo' to get { uid: 'devUserVerifiedFoo', isAnonymous: false }
-  if (['development', 'test'].includes(process.env.NODE_ENV) && /devUser/u.test(token)) {
+  if (['development', 'test'].includes(process.env.NODE_ENV) && /^devUser/u.test(token)) {
     return { uid: token, isAnonymous: !/Verified/u.test(token) };
   }
 


### PR DESCRIPTION
- Update JWT helpers for Jest work.
- Add Prisma migrate functions for jest.
- Add tests for /user.
- Require `getUserFromJwt()` input to fail on `Bearer ${token}`.
