### PR TITLE
Fix validation of inputs that can be an integer

### DIFF
--- a/pages/api/applications/[applicationId].ts
+++ b/pages/api/applications/[applicationId].ts
@@ -6,6 +6,7 @@ import { Nullable } from '../../../types/utils';
 import { withAuthUser } from '../../../utils/auth/jwtHelpers';
 import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '../../../utils/http/httpHelpers';
 import { withPrismaErrorHandling } from '../../../utils/prisma/prismaHelpers';
+import { canBecomeInteger } from '../../../utils/numbers/validations';
 
 const prisma = new PrismaClient();
 
@@ -43,7 +44,7 @@ async function handler(userId: string, req: NextApiRequest, res: NextApiResponse
 }
 
 async function handleGet(userId: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<ApplicationData>>) {
-  if (!Number.isInteger(req.query.applicationId)) {
+  if (!canBecomeInteger(req.query.applicationId)) {
     res.status(HttpStatus.BAD_REQUEST).json(createJsonResponse({}, messages[MessageType.APPLICATION_ID_INVALID]));
     return;
   }

--- a/pages/api/applications/[applicationId].ts
+++ b/pages/api/applications/[applicationId].ts
@@ -97,7 +97,7 @@ async function handleGet(userId: string, req: NextApiRequest, res: NextApiRespon
 }
 
 async function handleDelete(userId: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<EmptyPayload>>) {
-  if (!Number.isInteger(req.query.applicationId)) {
+  if (!canBecomeInteger(req.query.applicationId)) {
     res.status(HttpStatus.BAD_REQUEST).json(createJsonResponse({}, messages[MessageType.APPLICATION_ID_INVALID]));
     return;
   }

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -8,6 +8,7 @@ import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '..
 import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';
 import { ApiResponse, EmptyPayload, StatusMessageType } from '../../../../../types/apiResponse';
 import { Nullable } from '../../../../../types/utils';
+import { canBecomeInteger } from '../../../../../utils/numbers/validations';
 
 enum MessageType {
   APPLICATION_STAGE_DELETE_UNAUTHORIZED,
@@ -168,11 +169,11 @@ async function handleDelete(userId: string, req: NextApiRequest, res: NextApiRes
 }
 
 function validatePatchRequest(req: NextApiRequest) {
-  if (!Number.isInteger(req.query.stageId)) {
+  if (!canBecomeInteger(req.query.stageId)) {
     return MessageType.INVALID_APPLICATION_STAGE_ID;
   }
 
-  if (!Number.isInteger(req.query.applicationId)) {
+  if (!canBecomeInteger(req.query.applicationId)) {
     return MessageType.INVALID_APPLICATION_ID;
   }
 
@@ -218,11 +219,11 @@ function makePatchData(req: NextApiRequest) {
 }
 
 function validateDeleteRequest(req: NextApiRequest) {
-  if (!Number.isInteger(req.query.stageId)) {
+  if (!canBecomeInteger(req.query.stageId)) {
     return MessageType.INVALID_APPLICATION_STAGE_ID;
   }
 
-  if (!Number.isInteger(req.query.applicationId)) {
+  if (!canBecomeInteger(req.query.applicationId)) {
     return MessageType.INVALID_APPLICATION_ID;
   }
 

--- a/pages/api/applications/[applicationId]/tasks/index.ts
+++ b/pages/api/applications/[applicationId]/tasks/index.ts
@@ -8,6 +8,7 @@ import { isValidDate } from '../../../../../utils/date/validations';
 import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '../../../../../utils/http/httpHelpers';
 import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';
 import { isEmpty } from '../../../../../utils/strings/validations';
+import { canBecomeInteger } from '../../../../../utils/numbers/validations';
 
 const prisma = new PrismaClient();
 
@@ -67,7 +68,7 @@ async function handler(userId: string, req: NextApiRequest, res: NextApiResponse
 }
 
 async function handlePost(userId: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<TaskData>>) {
-  if (!Number.isInteger(req.query.applicationId)) {
+  if (!canBecomeInteger(req.query.applicationId)) {
     res.status(HttpStatus.BAD_REQUEST).json(createJsonResponse({}, messages[MessageType.TASK_APPLICATION_ID_INVALID]));
     return;
   }

--- a/pages/api/roles/index.ts
+++ b/pages/api/roles/index.ts
@@ -9,6 +9,7 @@ import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '..
 import { withPrismaErrorHandling } from '../../../utils/prisma/prismaHelpers';
 import { capitalizeEveryWord } from '../../../utils/strings/formatters';
 import { isEmpty } from '../../../utils/strings/validations';
+import { canBecomeInteger } from '../../../utils/numbers/validations';
 
 const prisma = new PrismaClient();
 
@@ -69,18 +70,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 async function handleGet(req: NextApiRequest, res: NextApiResponse<ApiResponse<RoleListData[]>>) {
   const { companyId, searchQuery } = req.query as RoleQueryParams;
 
-  const queryCompanyId = typeof companyId == 'string' && Number.isInteger(companyId) ? Number(companyId) : undefined;
+  const queryCompanyId = typeof companyId == 'string' && canBecomeInteger(companyId) ? Number(companyId) : undefined;
 
   const searchWords = typeof searchQuery == 'string' && !isEmpty(searchQuery) ? searchQuery.trim().split(/\s+/) : [];
 
   const searchInts = searchWords
-    .filter(Number.isInteger)
+    .filter(canBecomeInteger)
     .map(Number)
     .filter((year) => year >= MIN_ROLE_YEAR);
   const queryYear = searchInts.length > 0 ? searchInts[0] : undefined;
 
   const queryWords = searchWords
-    .filter((word) => !(Number.isInteger(word) && Number(word) >= MIN_ROLE_YEAR))
+    .filter((word) => !(canBecomeInteger(word) && Number(word) >= MIN_ROLE_YEAR))
     .map((word) => ({
       title: {
         contains: word,

--- a/utils/numbers/validations.ts
+++ b/utils/numbers/validations.ts
@@ -1,0 +1,4 @@
+export function canBecomeInteger(value: unknown) {
+  const number = Number(value);
+  return !isNaN(number) && Number.isInteger(number);
+}

--- a/utils/numbers/validations.ts
+++ b/utils/numbers/validations.ts
@@ -1,4 +1,4 @@
 export function canBecomeInteger(value: unknown) {
-  const number = Number(value);
-  return !isNaN(number) && Number.isInteger(number);
+  const valueIsFalsyAndNotZero = value !== 0 && !value;
+  return !valueIsFalsyAndNotZero && Number.isInteger(Number(value));
 }


### PR DESCRIPTION
- Fields that should be `number` should still use `Number.isInteger`
- Fields that can be any type, but can become an integer, should use `canBeInteger`
- Note: `Number('')`, `Number(false)` and `Number(null)` gives 0 in javascript. Edit: Will guard against these.