### PR TITLE
Require payload member types to be string or number.

### DIFF
--- a/__tests__/pages/api/applications/[applicationId]/stages/index.test.ts
+++ b/__tests__/pages/api/applications/[applicationId]/stages/index.test.ts
@@ -38,10 +38,15 @@ describe('POST to create stage works.', () => {
     });
   }
 
-  canCreateWithPost('full', { type: 'OFFERED', date: new Date(), emojiUnicodeHex: '1f604', remark: 'Foo' });
-  canCreateWithPost('minimal', { type: 'OFFERED', date: new Date() });
-  canCreateWithPost('null emoji', { type: 'OFFERED', date: new Date(), emojiUnicodeHex: null, remark: 'Foo' });
-  canCreateWithPost('null remark', { type: 'OFFERED', date: new Date(), emojiUnicodeHex: '1f604', remark: null });
+  canCreateWithPost('full', { type: 'OFFERED', date: new Date().toJSON(), emojiUnicodeHex: '1f604', remark: 'Foo' });
+  canCreateWithPost('minimal', { type: 'OFFERED', date: new Date().toJSON() });
+  canCreateWithPost('null emoji', { type: 'OFFERED', date: new Date().toJSON(), emojiUnicodeHex: null, remark: 'Foo' });
+  canCreateWithPost('null remark', {
+    type: 'OFFERED',
+    date: new Date().toJSON(),
+    emojiUnicodeHex: '1f604',
+    remark: null,
+  });
 
   it('Does not POST with bad applicationId', async () => {
     const uid = await createUser(prisma, { type: 'APPLIED', date: '2022-10-01' });
@@ -50,7 +55,7 @@ describe('POST to create stage works.', () => {
     const type = 'OFFERED';
     const { req, res, getResult } = createStagePostMocks(uid, applicationId, {
       type,
-      date: new Date(),
+      date: new Date().toJSON(),
     });
 
     await stagesHandler(req, res);
@@ -66,7 +71,7 @@ describe('POST to create stage works.', () => {
     const type = 'OFFERED';
     const { req, res, getResult } = createStagePostMocks(uid, applicationId, {
       type,
-      date: new Date(),
+      date: new Date().toJSON(),
     });
 
     await stagesHandler(req, res);
@@ -82,7 +87,7 @@ describe('POST to create stage works.', () => {
     const type = 'OFFERE' as 'OFFERED';
     const { req, res, getResult } = createStagePostMocks(uid, applicationId, {
       type,
-      date: new Date(),
+      date: new Date().toJSON(),
     });
 
     await stagesHandler(req, res);
@@ -99,7 +104,7 @@ describe('POST to create stage works.', () => {
       const type = 'OFFERED';
       const { req, res, getResult } = createStagePostMocks(uid, applicationId, {
         type,
-        date: notDate as Date,
+        date: notDate,
       });
 
       await stagesHandler(req, res);

--- a/__tests__/pages/api/applications/[applicationId]/stages/index.test.ts
+++ b/__tests__/pages/api/applications/[applicationId]/stages/index.test.ts
@@ -9,6 +9,7 @@ import stagesHandler from '../../../../../../pages/api/applications/[application
 import { HttpMethod, HttpStatus } from '../../../../../../utils/http/httpHelpers';
 import { ApplicationStagePostData } from '../../../../../../types/applicationStage';
 import { ApplicationStageType, PrismaClient, User } from '@prisma/client';
+import { convertApplicationStageToPayload } from '../../../../../../utils/applicationStage/converter';
 
 beforeAll(prismaMigrateReset);
 afterAll(prismaMigrateReset);
@@ -31,10 +32,9 @@ describe('POST to create stage works.', () => {
 
       const stage = await prisma.applicationStage.findFirstOrThrow({
         where: { applicationId, type: body.type },
-        select: { date: true, emojiUnicodeHex: true, id: true, remark: true, type: true, applicationId: true },
       });
       expect(status).toBe(HttpStatus.CREATED);
-      expect(json.payload).toEqual(stage);
+      expect(json.payload).toEqual(convertApplicationStageToPayload(stage));
     });
   }
 

--- a/__tests__/pages/api/applications/[applicationId]/tasks/[taskId].ts
+++ b/__tests__/pages/api/applications/[applicationId]/tasks/[taskId].ts
@@ -64,11 +64,9 @@ describe('PATCH tasks', () => {
 
     expect(status).toEqual(HttpStatus.OK);
     expect(
-      (
-        await prisma.task.findMany({
-          where: { applicationId },
-        })
-      ).map(convertTaskToPayload),
+      await prisma.task.findMany({
+        where: { applicationId },
+      }),
     ).toEqual(tasks);
   });
 
@@ -120,7 +118,7 @@ describe('DELETE tasks', () => {
     const { status, json } = getResult();
 
     expect(status).toEqual(HttpStatus.NOT_FOUND);
-    expect((await prisma.task.findMany({ where: { applicationId } })).map(convertTaskToPayload)).toEqual(tasks);
+    expect(await prisma.task.findMany({ where: { applicationId } })).toEqual(tasks);
   });
 
   it('Fails to DELETE non-user tasks.', async () => {
@@ -132,7 +130,7 @@ describe('DELETE tasks', () => {
     const { status, json } = getResult();
 
     expect(status).toEqual(HttpStatus.NOT_FOUND);
-    expect((await prisma.task.findMany({ where: { applicationId } })).map(convertTaskToPayload)).toEqual(tasks);
+    expect(await prisma.task.findMany({ where: { applicationId } })).toEqual(tasks);
   });
 });
 

--- a/api/api.ts
+++ b/api/api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios, { AxiosError, AxiosPromise, AxiosResponse } from 'axios';
-import { ApiPromise, ApiResponse, StatusMessageType } from '../types/apiResponse';
+import { ApiPromise, ApiResponse, Payload, StatusMessageType } from '../types/apiResponse';
 
 class BaseApi {
   client = axios.create({
@@ -8,40 +8,40 @@ class BaseApi {
     timeout: 10 * 1000, // 10 seconds
   });
 
-  private getData<D>(url: string, params?: any): AxiosPromise<ApiResponse<D>> {
+  private getData<D extends Payload>(url: string, params?: any): AxiosPromise<ApiResponse<D>> {
     return this.client.get(url, params);
   }
 
-  private postData<D>(url: string, data: any = {}): AxiosPromise<ApiResponse<D>> {
+  private postData<D extends Payload>(url: string, data: any = {}): AxiosPromise<ApiResponse<D>> {
     return this.client.post(url, data);
   }
 
-  private patchData<D>(url: string, data: any = {}): AxiosPromise<ApiResponse<D>> {
+  private patchData<D extends Payload>(url: string, data: any = {}): AxiosPromise<ApiResponse<D>> {
     return this.client.patch(url, data);
   }
 
-  private deleteData<D>(url: string): AxiosPromise<ApiResponse<D>> {
+  private deleteData<D extends Payload>(url: string): AxiosPromise<ApiResponse<D>> {
     return this.client.delete(url);
   }
 
-  public get<D>(url: string, params?: any): ApiPromise<D> {
+  public get<D extends Payload>(url: string, params?: any): ApiPromise<D> {
     return processRequest(url, this.getData(url, params));
   }
 
-  public post<D>(url: string, data: any = {}): ApiPromise<D> {
+  public post<D extends Payload>(url: string, data: any = {}): ApiPromise<D> {
     return processRequest(url, this.postData(url, data));
   }
 
-  public patch<D>(url: string, data: any = {}): ApiPromise<D> {
+  public patch<D extends Payload>(url: string, data: any = {}): ApiPromise<D> {
     return processRequest(url, this.patchData(url, data));
   }
 
-  public delete<D>(url: string): ApiPromise<D> {
+  public delete<D extends Payload>(url: string): ApiPromise<D> {
     return processRequest(url, this.deleteData(url));
   }
 }
 
-function processRequest<D>(endpoint: string, promise: AxiosPromise<ApiResponse<D>>): ApiPromise<D> {
+function processRequest<D extends Payload>(endpoint: string, promise: AxiosPromise<ApiResponse<D>>): ApiPromise<D> {
   return promise
     .then((response: AxiosResponse<ApiResponse<D>>) => {
       const apiResponse = response.data;
@@ -61,7 +61,7 @@ function processRequest<D>(endpoint: string, promise: AxiosPromise<ApiResponse<D
     });
 }
 
-function makeApiErrorResponse<D>(error: AxiosError<ApiResponse<D>>): ApiResponse<D> {
+function makeApiErrorResponse<D extends Payload>(error: AxiosError<ApiResponse<D>>): ApiResponse<D> {
   if (!error?.response?.data.messages) {
     return {
       payload: {},

--- a/pages/api/applications/[applicationId].ts
+++ b/pages/api/applications/[applicationId].ts
@@ -31,7 +31,7 @@ const messages = Object.freeze({
   },
 });
 
-async function handler(userId: string, req: NextApiRequest, res: NextApiResponse) {
+async function handler(userId: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<ApplicationData>>) {
   const method = req.method;
 
   switch (method) {

--- a/pages/api/applications/[applicationId].ts
+++ b/pages/api/applications/[applicationId].ts
@@ -2,7 +2,6 @@ import { ApplicationStage, Company, PrismaClient, Role, Task } from '@prisma/cli
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResponse, EmptyPayload, StatusMessageType } from '../../../types/apiResponse';
 import { ApplicationData } from '../../../types/application';
-import { Nullable } from '../../../types/utils';
 import { withAuthUser } from '../../../utils/auth/jwtHelpers';
 import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '../../../utils/http/httpHelpers';
 import { withPrismaErrorHandling } from '../../../utils/prisma/prismaHelpers';

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -110,7 +110,7 @@ async function handlePatch(
     },
     data: {
       type: applicationStagePatchData.type,
-      date: applicationStagePatchData.date,
+      date: applicationStagePatchData.date ? new Date(applicationStagePatchData.date) : undefined,
       emojiUnicodeHex: applicationStagePatchData.emojiUnicodeHex,
       remark: applicationStagePatchData.remark,
     },
@@ -216,7 +216,7 @@ function makePatchData(req: NextApiRequest) {
   }
 
   if (req.body.date !== undefined) {
-    applicationStagePatchData.date = new Date(req.body.date);
+    applicationStagePatchData.date = req.body.date;
   }
 
   if (req.body.emojiUnicodeHex !== undefined) {

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { ApplicationStage, ApplicationStageType, PrismaClient } from '@prisma/client';
+import { ApplicationStageType, PrismaClient } from '@prisma/client';
 import { ApplicationStageData, ApplicationStagePatchData } from '../../../../../types/applicationStage';
 import { isValidHex } from '../../../../../utils/strings/validations';
 import { withAuthUser } from '../../../../../utils/auth/jwtHelpers';

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -8,6 +8,7 @@ import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '..
 import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';
 import { ApiResponse, EmptyPayload, StatusMessageType } from '../../../../../types/apiResponse';
 import { canBecomeInteger } from '../../../../../utils/numbers/validations';
+import { convertApplicationStageToPayload } from '../../../../../utils/applicationStage/converter';
 
 enum MessageType {
   APPLICATION_STAGE_DELETE_UNAUTHORIZED,
@@ -137,7 +138,7 @@ async function handlePatch(
     .status(HttpStatus.OK)
     .json(
       createJsonResponse(
-        createPayload(updatedApplicationStage),
+        convertApplicationStageToPayload(updatedApplicationStage),
         messages[MessageType.APPLICATION_STAGE_UPDATED_SUCCESSFULLY],
       ),
     );

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { ApplicationStageType, PrismaClient } from '@prisma/client';
+import { ApplicationStage, ApplicationStageType, PrismaClient } from '@prisma/client';
 import { ApplicationStageData, ApplicationStagePatchData } from '../../../../../types/applicationStage';
 import { isValidHex } from '../../../../../utils/strings/validations';
 import { withAuthUser } from '../../../../../utils/auth/jwtHelpers';
@@ -7,7 +7,6 @@ import { isValidDate } from '../../../../../utils/date/validations';
 import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '../../../../../utils/http/httpHelpers';
 import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';
 import { ApiResponse, EmptyPayload, StatusMessageType } from '../../../../../types/apiResponse';
-import { Nullable } from '../../../../../types/utils';
 import { canBecomeInteger } from '../../../../../utils/numbers/validations';
 
 enum MessageType {
@@ -123,11 +122,10 @@ async function handlePatch(
     return;
   }
 
-  const updatedApplicationStage: Nullable<ApplicationStageData> = await prisma.applicationStage.findUnique({
+  const updatedApplicationStage = await prisma.applicationStage.findUnique({
     where: {
       id: applicationStageId,
     },
-    select: { id: true, applicationId: true, type: true, date: true, emojiUnicodeHex: true, remark: true },
   });
 
   if (!updatedApplicationStage) {
@@ -137,7 +135,12 @@ async function handlePatch(
 
   res
     .status(HttpStatus.OK)
-    .json(createJsonResponse(updatedApplicationStage, messages[MessageType.APPLICATION_STAGE_UPDATED_SUCCESSFULLY]));
+    .json(
+      createJsonResponse(
+        createPayload(updatedApplicationStage),
+        messages[MessageType.APPLICATION_STAGE_UPDATED_SUCCESSFULLY],
+      ),
+    );
 }
 
 async function handleDelete(userId: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<EmptyPayload>>) {

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -96,7 +96,12 @@ async function handlePatch(
   const applicationStageId = Number(req.query.stageId);
   const applicationId = Number(req.query.applicationId);
 
-  const applicationStagePatchData: ApplicationStagePatchData = makePatchData(req);
+  const applicationStagePatchData: ApplicationStagePatchData = {
+    type: req.body.type,
+    date: req.body.date,
+    emojiUnicodeHex: req.body.emojiUnicodeHex,
+    remark: req.body.remark,
+  };
 
   // Note: updateMany is used to allow filter on non-unique columns.
   // This allows a check to ensure users are only updating their own application stages.
@@ -206,28 +211,6 @@ function validatePatchRequest(req: NextApiRequest) {
   }
 
   return null;
-}
-
-function makePatchData(req: NextApiRequest) {
-  const applicationStagePatchData: ApplicationStagePatchData = {};
-
-  if (req.body.type !== undefined) {
-    applicationStagePatchData.type = req.body.type;
-  }
-
-  if (req.body.date !== undefined) {
-    applicationStagePatchData.date = req.body.date;
-  }
-
-  if (req.body.emojiUnicodeHex !== undefined) {
-    applicationStagePatchData.emojiUnicodeHex = req.body.emojiUnicodeHex || null;
-  }
-
-  if (req.body.remark !== undefined) {
-    applicationStagePatchData.remark = req.body.remark || null;
-  }
-
-  return applicationStagePatchData;
 }
 
 function validateDeleteRequest(req: NextApiRequest) {

--- a/pages/api/applications/[applicationId]/stages/[stageId].ts
+++ b/pages/api/applications/[applicationId]/stages/[stageId].ts
@@ -70,7 +70,7 @@ const messages = Object.freeze({
   },
 });
 
-async function handler(userId: string, req: NextApiRequest, res: NextApiResponse) {
+async function handler(userId: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<ApplicationStageData>>) {
   const method = req.method;
   switch (method) {
     case HttpMethod.PATCH:

--- a/pages/api/applications/[applicationId]/stages/index.ts
+++ b/pages/api/applications/[applicationId]/stages/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { ApplicationStage, ApplicationStageType, PrismaClient } from '@prisma/client';
+import { ApplicationStageType, PrismaClient } from '@prisma/client';
 import { ApiResponse, StatusMessageType } from '../../../../../types/apiResponse';
 import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '../../../../../utils/http/httpHelpers';
 import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';

--- a/pages/api/applications/[applicationId]/stages/index.ts
+++ b/pages/api/applications/[applicationId]/stages/index.ts
@@ -72,8 +72,8 @@ async function handlePost(uid: string, req: NextApiRequest, res: NextApiResponse
     return res.status(HttpStatus.NOT_FOUND).json(createJsonResponse({}, messages[MessageType.APPLICATION_NOT_FOUND]));
   }
 
-  const { type, date, emojiUnicodeHex, remark } = req.body;
-  const parameters: ApplicationStagePostData = { type, date: new Date(date), emojiUnicodeHex, remark };
+  const { type, date, emojiUnicodeHex, remark } = req.body as ApplicationStagePostData;
+  const parameters = { type, date: new Date(date), emojiUnicodeHex, remark };
 
   const newStage = await prisma.applicationStage.create({
     data: { ...parameters, applicationId: application.id },

--- a/pages/api/applications/[applicationId]/stages/index.ts
+++ b/pages/api/applications/[applicationId]/stages/index.ts
@@ -9,6 +9,7 @@ import { withAuthUser } from '../../../../../utils/auth/jwtHelpers';
 import { Nullable } from '../../../../../types/utils';
 import { isValidHex } from '../../../../../utils/strings/validations';
 import { canBecomeInteger } from '../../../../../utils/numbers/validations';
+import { convertApplicationStageToPayload } from '../../../../../utils/applicationStage/converter';
 
 const prisma = new PrismaClient();
 
@@ -80,7 +81,7 @@ async function handlePost(uid: string, req: NextApiRequest, res: NextApiResponse
 
   return res
     .status(HttpStatus.CREATED)
-    .json(createJsonResponse(createPayload(newStage), messages[MessageType.CREATED]));
+    .json(createJsonResponse(convertApplicationStageToPayload(newStage), messages[MessageType.CREATED]));
 }
 
 function validatePathParameters(req: NextApiRequest): Nullable<MessageType> {
@@ -117,11 +118,6 @@ function validatePostRequest(req: NextApiRequest): Nullable<MessageType> {
   }
 
   return null;
-}
-
-function createPayload(stage: ApplicationStage): ApplicationStageData {
-  const { applicationId, id, type, date, emojiUnicodeHex, remark } = stage;
-  return { applicationId, id, type, date: date.toJSON(), emojiUnicodeHex, remark };
 }
 
 export default withPrismaErrorHandling(withAuthUser(handler));

--- a/pages/api/applications/[applicationId]/tasks/[taskId].ts
+++ b/pages/api/applications/[applicationId]/tasks/[taskId].ts
@@ -101,11 +101,11 @@ async function handleDelete(uid: string, req: NextApiRequest, res: NextApiRespon
 
 function validatePathParameters(req: NextApiRequest): Nullable<MessageType> {
   const { taskId, applicationId } = req.query;
-  if (canBecomeInteger(taskId)) {
+  if (!canBecomeInteger(taskId)) {
     return MessageType.INVALID_TASK_ID;
   }
 
-  if (canBecomeInteger(applicationId)) {
+  if (!canBecomeInteger(applicationId)) {
     return MessageType.INVALID_APPLICATION_ID;
   }
 

--- a/pages/api/applications/[applicationId]/tasks/[taskId].ts
+++ b/pages/api/applications/[applicationId]/tasks/[taskId].ts
@@ -10,6 +10,7 @@ import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '..
 import { canBecomeInteger } from '../../../../../utils/numbers/validations';
 import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';
 import { isEmpty } from '../../../../../utils/strings/validations';
+import { convertTaskToPayload } from '../../../../../utils/task/converter';
 
 const prisma = new PrismaClient();
 
@@ -79,7 +80,7 @@ async function handlePatch(uid: string, req: NextApiRequest, res: NextApiRespons
   const updatedTask: Task = await prisma.task.update({ where: { id: taskId }, data });
   return res
     .status(HttpStatus.OK)
-    .json(createJsonResponse(updatedTask, messages[MessageType.TASK_UPDATED_SUCCESSFULLY]));
+    .json(createJsonResponse(convertTaskToPayload(updatedTask), messages[MessageType.TASK_UPDATED_SUCCESSFULLY]));
 }
 
 async function handleDelete(uid: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<EmptyPayload>>) {

--- a/pages/api/applications/[applicationId]/tasks/index.ts
+++ b/pages/api/applications/[applicationId]/tasks/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Task } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResponse, StatusMessageType } from '../../../../../types/apiResponse';
 import { TaskData, TaskPostData } from '../../../../../types/task';
@@ -9,6 +9,7 @@ import { createJsonResponse, HttpMethod, HttpStatus, rejectHttpMethod } from '..
 import { withPrismaErrorHandling } from '../../../../../utils/prisma/prismaHelpers';
 import { isEmpty } from '../../../../../utils/strings/validations';
 import { canBecomeInteger } from '../../../../../utils/numbers/validations';
+import { convertTaskToPayload } from '../../../../../utils/task/converter';
 
 const prisma = new PrismaClient();
 
@@ -105,10 +106,11 @@ async function handlePost(userId: string, req: NextApiRequest, res: NextApiRespo
       applicationId,
       ...taskPostData,
     },
-    select: { id: true, title: true, dueDate: true, notificationDateTime: true, isDone: true },
   });
 
-  res.status(HttpStatus.CREATED).json(createJsonResponse(newTask, messages[MessageType.TASK_CREATED_SUCCESSFULLY]));
+  res
+    .status(HttpStatus.CREATED)
+    .json(createJsonResponse(convertTaskToPayload(newTask), messages[MessageType.TASK_CREATED_SUCCESSFULLY]));
 }
 
 function validatePostRequest(req: NextApiRequest): Nullable<MessageType> {

--- a/pages/api/applications/[applicationId]/tasks/index.ts
+++ b/pages/api/applications/[applicationId]/tasks/index.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResponse, StatusMessageType } from '../../../../../types/apiResponse';
-import { TaskData, TaskPostData } from '../../../../../types/task';
+import { TaskData } from '../../../../../types/task';
 import { Nullable } from '../../../../../types/utils';
 import { withAuthUser } from '../../../../../utils/auth/jwtHelpers';
 import { isValidDate } from '../../../../../utils/date/validations';
@@ -95,7 +95,7 @@ async function handlePost(userId: string, req: NextApiRequest, res: NextApiRespo
     return;
   }
 
-  const taskPostData: TaskPostData = {
+  const taskPostData = {
     title: req.body.title,
     dueDate: new Date(req.body.dueDate),
     notificationDateTime: req.body.notificationDateTime ? new Date(req.body.notificationDateTime) : null,

--- a/pages/api/applications/[applicationId]/tasks/index.ts
+++ b/pages/api/applications/[applicationId]/tasks/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Task } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResponse, StatusMessageType } from '../../../../../types/apiResponse';
 import { TaskData, TaskPostData } from '../../../../../types/task';

--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -224,7 +224,7 @@ function convertApplicationListDataToPayload({
 }: {
   id: number;
   role: Role & { company: Company };
-  latestStage: ApplicationStage;
+  latestStage: ApplicationStage | undefined;
   taskNotificationCount: number;
 }): ApplicationListData {
   const { company, title, type, year } = role;
@@ -238,7 +238,7 @@ function convertApplicationListDataToPayload({
       id: role.id,
       company: { id: company.id, name: company.name, companyUrl: company.companyUrl },
     },
-    latestStage: convertApplicationStageToPayload(latestStage),
+    latestStage: latestStage ? convertApplicationStageToPayload(latestStage) : undefined,
   };
 }
 

--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -106,12 +106,13 @@ async function handleGet(
     .map((application) => ({
       id: application.id,
       role: application.role,
-      latestStage: application.applicationStages[0],
+      latestStage: application.applicationStages.length > 0 ? application.applicationStages[0] : undefined,
       taskNotificationCount: application._count.tasks,
     }))
     .filter(
       (application) =>
-        !hasSelectedApplicationStageTypes || application.latestStage?.type in selectedApplicationStageTypes,
+        !hasSelectedApplicationStageTypes ||
+        (application.latestStage && selectedApplicationStageTypes.includes(application.latestStage?.type)),
     )
     .sort(
       (firstApplication, secondApplication) =>

--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -44,7 +44,11 @@ const messages = Object.freeze({
   [MessageType.INVALID_ROLE_ID]: { type: StatusMessageType.ERROR, message: 'Application role id is invalid.' },
 });
 
-async function handler(userId: string, req: NextApiRequest, res: NextApiResponse) {
+async function handler(
+  userId: string,
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse<ApplicationListData[] | ApplicationRoleData>>,
+) {
   const method = req.method;
   switch (method) {
     case HttpMethod.GET:

--- a/types/apiResponse.ts
+++ b/types/apiResponse.ts
@@ -8,13 +8,19 @@ export interface StatusMessage {
   message: string;
 }
 
-export interface Response<D> {
+export interface Response<D extends Payload> {
   payload: D;
   messages: StatusMessage[];
 }
 
 export type EmptyPayload = Record<string, never>;
 
-export type ApiResponse<D> = Response<D | EmptyPayload>;
+export type ApiResponse<D extends Payload> = Response<D | EmptyPayload>;
 
-export type ApiPromise<D> = Promise<ApiResponse<D>>;
+export type Payload = PayloadInterface | PayloadInterface[];
+
+interface PayloadInterface {
+  [key: string]: undefined | null | string | number | boolean | Payload | string[] | number[] | Payload[];
+}
+
+export type ApiPromise<D extends Payload> = Promise<ApiResponse<D>>;

--- a/types/applicationStage.ts
+++ b/types/applicationStage.ts
@@ -28,6 +28,6 @@ export type ApplicationStagePatchData = {
 export type ApplicationStageApplicationListData = {
   id: number;
   type: ApplicationStageType;
-  date: Date;
+  date: string;
   emojiUnicodeHex: Nullable<string>;
 };

--- a/types/applicationStage.ts
+++ b/types/applicationStage.ts
@@ -4,7 +4,7 @@ import { Nullable } from './utils';
 export type ApplicationStageApplicationData = {
   id: number;
   type: ApplicationStageType;
-  date: Date;
+  date: string;
   emojiUnicodeHex: Nullable<string>;
   remark: Nullable<string>;
 };

--- a/types/applicationStage.ts
+++ b/types/applicationStage.ts
@@ -13,14 +13,14 @@ export type ApplicationStageData = ApplicationStageApplicationData & { applicati
 
 export type ApplicationStagePostData = {
   type: ApplicationStageType;
-  date: Date;
+  date: string;
   emojiUnicodeHex?: Nullable<string>; // will be set to null if empty or undefined.
   remark?: Nullable<string>; // will be set to null if empty or undefined.
 };
 
 export type ApplicationStagePatchData = {
   type?: ApplicationStageType;
-  date?: Date;
+  date?: string;
   emojiUnicodeHex?: Nullable<string>;
   remark?: Nullable<string>;
 };

--- a/types/task.ts
+++ b/types/task.ts
@@ -7,14 +7,14 @@ export type TaskQueryParams = {
 
 export type TaskPostData = {
   title: string;
-  dueDate: Date;
-  notificationDateTime: Nullable<Date>;
+  dueDate: string;
+  notificationDateTime: Nullable<string>;
 };
 
 export type TaskPatchData = {
   title?: string;
-  dueDate?: Date;
-  notificationDateTime?: Nullable<Date>;
+  dueDate?: string;
+  notificationDateTime?: Nullable<string>;
   isDone?: boolean;
 };
 

--- a/types/task.ts
+++ b/types/task.ts
@@ -21,7 +21,7 @@ export type TaskPatchData = {
 export type TaskData = {
   id: number;
   title: string;
-  dueDate: Date;
-  notificationDateTime: Nullable<Date>;
+  dueDate: string;
+  notificationDateTime: Nullable<string>;
   isDone: boolean;
 };

--- a/utils/applicationStage/converter.ts
+++ b/utils/applicationStage/converter.ts
@@ -1,0 +1,7 @@
+import { ApplicationStage } from '@prisma/client';
+import { ApplicationStageData } from '../../types/applicationStage';
+
+export function convertApplicationStageToPayload(stage: ApplicationStage): ApplicationStageData {
+  const { id, type, date, emojiUnicodeHex, remark, applicationId } = stage;
+  return { id, type, date: date.toJSON(), emojiUnicodeHex, remark, applicationId };
+}

--- a/utils/auth/jwtHelpers.ts
+++ b/utils/auth/jwtHelpers.ts
@@ -1,6 +1,6 @@
 import admin from 'firebase-admin';
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
-import { ApiResponse, StatusMessageType } from '../../types/apiResponse';
+import { ApiResponse, Payload, StatusMessageType } from '../../types/apiResponse';
 import { createJsonResponse, HttpStatus } from '../http/httpHelpers';
 
 export interface UserDetailsFromRequest {
@@ -33,7 +33,7 @@ const USER_NOT_AUTHORIZED = 'User has not verified their identity.';
  * @param handler Takes in an API handler function that needs an authenticated user.
  * @returns NextApiHandler function.
  */
-export function withAuthUser<D>(
+export function withAuthUser<D extends Payload>(
   handler: (uid: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<D>>) => void,
 ): NextApiHandler<ApiResponse<D>> {
   return async (req: NextApiRequest, res: NextApiResponse<ApiResponse<D>>) => {
@@ -59,7 +59,7 @@ export function withAuthUser<D>(
  * @param handler Takes in an API handler function that needs a verified user.
  * @returns NextApiHandler function.
  */
-export function withVerifiedUser<D>(
+export function withVerifiedUser<D extends Payload>(
   handler: (uid: string, req: NextApiRequest, res: NextApiResponse<ApiResponse<D>>) => void,
 ): NextApiHandler<ApiResponse<D>> {
   return async (req: NextApiRequest, res: NextApiResponse<ApiResponse<D>>) => {
@@ -94,7 +94,7 @@ export function withVerifiedUser<D>(
  * @param handler Takes in an API handler function that needs an authenticated user.
  * @returns NextApiHandler function.
  */
-export function withAuth<D>(
+export function withAuth<D extends Payload>(
   handler: (req: NextApiRequest, res: NextApiResponse<ApiResponse<D>>) => void,
 ): NextApiHandler<ApiResponse<D>> {
   return withAuthUser((_, req, res) => handler(req, res));

--- a/utils/http/httpHelpers.ts
+++ b/utils/http/httpHelpers.ts
@@ -1,5 +1,5 @@
 import { NextApiResponse } from 'next';
-import { ApiResponse, StatusMessage, StatusMessageType } from '../../types/apiResponse';
+import { ApiResponse, Payload, StatusMessage, StatusMessageType } from '../../types/apiResponse';
 
 export enum HttpMethod {
   GET = 'GET',
@@ -40,6 +40,6 @@ export function rejectHttpMethod(res: NextApiResponse, method?: string) {
     );
 }
 
-export function createJsonResponse<D>(payload: D, ...messages: StatusMessage[]): ApiResponse<D> {
+export function createJsonResponse<D extends Payload>(payload: D, ...messages: StatusMessage[]): ApiResponse<D> {
   return { payload, messages };
 }

--- a/utils/prisma/prismaHelpers.ts
+++ b/utils/prisma/prismaHelpers.ts
@@ -6,7 +6,7 @@ import {
   PrismaClientValidationError,
 } from '@prisma/client/runtime';
 import { NextApiHandler } from 'next';
-import { ApiResponse, StatusMessageType } from '../../types/apiResponse';
+import { ApiResponse, Payload, StatusMessageType } from '../../types/apiResponse';
 import { createJsonResponse, HttpStatus } from '../http/httpHelpers';
 
 // Unsolvable from user perspective.
@@ -50,7 +50,9 @@ type PrismaErrors =
   | PrismaClientInitializationError
   | PrismaClientValidationError;
 
-export function withPrismaErrorHandling<D>(handler: NextApiHandler<ApiResponse<D>>): NextApiHandler<ApiResponse<D>> {
+export function withPrismaErrorHandling<D extends Payload>(
+  handler: NextApiHandler<ApiResponse<D>>,
+): NextApiHandler<ApiResponse<D>> {
   return async (req, res) => {
     try {
       await Promise.resolve(handler(req, res));

--- a/utils/task/converter.ts
+++ b/utils/task/converter.ts
@@ -1,0 +1,13 @@
+import { Task } from '@prisma/client';
+import { TaskData } from '../../types/task';
+
+export function convertTaskToPayload(task: Task): TaskData {
+  const { id, title, dueDate, notificationDateTime, isDone } = task;
+  return {
+    id,
+    title,
+    dueDate: dueDate.toJSON() ?? null,
+    notificationDateTime: notificationDateTime?.toJSON() ?? null,
+    isDone,
+  };
+}

--- a/utils/task/converter.ts
+++ b/utils/task/converter.ts
@@ -6,7 +6,7 @@ export function convertTaskToPayload(task: Task): TaskData {
   return {
     id,
     title,
-    dueDate: dueDate.toJSON() ?? null,
+    dueDate: dueDate.toJSON(),
     notificationDateTime: notificationDateTime?.toJSON() ?? null,
     isDone,
   };


### PR DESCRIPTION
- Set type standard for payloads.
- Update `BaseApi`.
- Update api/app/[:appId]/tasks
- Update stages type.
- Update api/app/:appId/stages
- Update api/app/:appId/stages/:stageId.
- Refactor to have a single converter.
- Create TaskData converter.
- Update api/applications.
- Put in explicit types for handlers.
