### PR TITLE
Create user on anonymous log in, and link if possible on github log in.

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -41,7 +41,10 @@ class BaseApi {
   }
 }
 
-function processRequest<D extends Payload>(endpoint: string, promise: AxiosPromise<ApiResponse<D>>): ApiPromise<D> {
+export function processRequest<D extends Payload>(
+  endpoint: string,
+  promise: AxiosPromise<ApiResponse<D>>,
+): ApiPromise<D> {
   return promise
     .then((response: AxiosResponse<ApiResponse<D>>) => {
       const apiResponse = response.data;

--- a/api/interceptor.tsx
+++ b/api/interceptor.tsx
@@ -36,7 +36,7 @@ const AxiosInterceptor = ({ children }: Props) => {
         return config;
       }
 
-      config.headers.Authorization = `Bearer ${jwtToken}`;
+      config.headers.Authorization = config.headers.Authorization || `Bearer ${jwtToken}`;
       config.paramsSerializer = toQueryString;
 
       return config;

--- a/api/usersApi.ts
+++ b/api/usersApi.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
-import { ApiPromise, ApiResponse } from '../types/apiResponse';
-import { UserData, UserPostData } from '../types/user';
-import api from './api';
+import { ApiPromise } from '../types/apiResponse';
+import { UserData } from '../types/user';
+import { processRequest } from './api';
 
 const USER_API_ENDPOINT = '/api/user';
 
@@ -9,10 +9,9 @@ const USER_API_ENDPOINT = '/api/user';
 // in the interceptor yet.
 class UsersApi {
   // Idempotent create account function. Successfully returns with no change if user exists.
-  public createAccount(newUserToken: string): ApiPromise<UserData> {
-    return axios.post(USER_API_ENDPOINT, {
-      headers: { Authorization: `Bearer ${newUserToken}` },
-    });
+  public createAccount(newToken: string, oldToken?: string): ApiPromise<UserData> {
+    const apiResult = axios.post(USER_API_ENDPOINT, { oldToken }, { headers: { Authorization: `Bearer ${newToken}` } });
+    return processRequest(USER_API_ENDPOINT, apiResult);
   }
 }
 

--- a/api/usersApi.ts
+++ b/api/usersApi.ts
@@ -1,12 +1,18 @@
-import { ApiPromise } from '../types/apiResponse';
+import axios from 'axios';
+import { ApiPromise, ApiResponse } from '../types/apiResponse';
 import { UserData, UserPostData } from '../types/user';
 import api from './api';
 
-export const USER_API_ENDPOINT = 'user';
+const USER_API_ENDPOINT = '/api/user';
 
+// This does not go through the interceptor as it is called in the authentication flow and the JWT token may not exist
+// in the interceptor yet.
 class UsersApi {
-  public linkAccount(userPostData: UserPostData): ApiPromise<UserData> {
-    return api.post(USER_API_ENDPOINT, userPostData);
+  // Idempotent create account function. Successfully returns with no change if user exists.
+  public createAccount(newUserToken: string): ApiPromise<UserData> {
+    return axios.post(USER_API_ENDPOINT, {
+      headers: { Authorization: `Bearer ${newUserToken}` },
+    });
   }
 }
 

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -5,6 +5,7 @@ import { useContext } from 'react';
 import logo from '../../assets/logoPlaceholder.png';
 import AuthContext from '../../context/AuthContext';
 import { StatusMessageType } from '../../types/apiResponse';
+import { removePreviousUserToken, storePreviousUserToken } from '../../utils/localStorage/temporaryUserKeyStorage';
 import { openNotification } from '../notification/Notifier';
 
 function Header() {
@@ -25,7 +26,11 @@ function Header() {
       allow_signup: 'false',
     });
 
-    signInWithRedirect(auth, provider);
+    const storeIfAnonymous = currentUser?.isAnonymous
+      ? currentUser.getIdToken(true).then(storePreviousUserToken)
+      : Promise.resolve();
+
+    storeIfAnonymous.then(() => signInWithRedirect(auth, provider));
   };
 
   const handleLogout = () => {
@@ -36,6 +41,8 @@ function Header() {
       });
       return;
     }
+
+    removePreviousUserToken();
 
     signOut(auth).finally(() => {
       window.location.reload();

--- a/hooks/useAnonymousLoginIfNeeded.ts
+++ b/hooks/useAnonymousLoginIfNeeded.ts
@@ -1,28 +1,16 @@
-import { getApps, initializeApp } from 'firebase/app';
+import { getApps } from 'firebase/app';
 import { Auth, getAuth, onAuthStateChanged, signInAnonymously, User } from 'firebase/auth';
 import { useCallback, useEffect, useState } from 'react';
 import { Nullable } from '../types/utils';
 
 /**
- * Hook that handles anonymous log in / register if not already logged in. This will also handle firebase
- * initialization if needed.
+ * Hook that handles anonymous log in / register if not already logged in.
  *
  * Note that this hook should not be needed in most cases as it is already called in `_app.tsx`.
  * Call this hook when firebase auth functions are required (e.g. `getAuth`, `signOut`, `signInWith`...)
  * Do not call this hook to access user object (Just use `AuthContext.Consumer`)
  */
 export default function useAnonymousLoginIfNeeded() {
-  const initFirebase = useCallback(() => {
-    initializeApp({
-      apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-      authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-      storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-      messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-      appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-    });
-  }, [initializeApp]);
-
   const [currentUser, setCurrentUser] = useState<User>();
   const [auth, setAuth] = useState<Auth>();
 
@@ -40,7 +28,7 @@ export default function useAnonymousLoginIfNeeded() {
 
   useEffect(() => {
     if (!getApps().length) {
-      initFirebase();
+      throw new Error('Firebase app has not been initiated.');
     }
 
     const auth = getAuth();

--- a/hooks/useFirebaseLogin.ts
+++ b/hooks/useFirebaseLogin.ts
@@ -1,6 +1,7 @@
 import { getApps } from 'firebase/app';
 import { Auth, getAuth, onAuthStateChanged, signInAnonymously, User } from 'firebase/auth';
 import { useCallback, useEffect, useState } from 'react';
+import usersApi from '../api/usersApi';
 import { Nullable } from '../types/utils';
 
 /**
@@ -16,13 +17,16 @@ export default function useFirebaseLogin() {
 
   const handleAuthStateChanged = useCallback(
     async (user: Nullable<User>) => {
-      if (user) {
-        setCurrentUser(user);
-      } else {
+      if (!user) {
         const auth = getAuth();
-        await signInAnonymously(auth);
+        const newUser = await signInAnonymously(auth);
+        user = newUser.user;
       }
+
+      setCurrentUser(user);
+      user.getIdToken().then(usersApi.createAccount);
     },
+
     [getAuth, signInAnonymously],
   );
 

--- a/hooks/useFirebaseLogin.ts
+++ b/hooks/useFirebaseLogin.ts
@@ -6,7 +6,7 @@ import { openNotification } from '../components/notification/Notifier';
 import { ApiResponse } from '../types/apiResponse';
 import { UserData } from '../types/user';
 import { Nullable } from '../types/utils';
-import { getPreviousUserToken } from '../utils/localStorage/temporaryUserKeyStorage';
+import { getPreviousUserToken, removePreviousUserToken } from '../utils/localStorage/temporaryUserKeyStorage';
 
 /**
  * Hook that handles anonymous log in / register if not already logged in or attaches the verified login.
@@ -31,7 +31,8 @@ export default function useFirebaseLogin() {
           const newUserToken = await user.getIdToken();
           usersApi
             .createAccount(newUserToken, oldUserToken)
-            .catch((result: ApiResponse<UserData>) => result.messages.forEach((message) => openNotification(message)));
+            .catch((result: ApiResponse<UserData>) => result.messages.forEach((message) => openNotification(message)))
+            .finally(removePreviousUserToken);
         }
       } else {
         const auth = getAuth();

--- a/hooks/useFirebaseLogin.ts
+++ b/hooks/useFirebaseLogin.ts
@@ -4,13 +4,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { Nullable } from '../types/utils';
 
 /**
- * Hook that handles anonymous log in / register if not already logged in.
+ * Hook that handles anonymous log in / register if not already logged in or attaches the verified login.
  *
  * Note that this hook should not be needed in most cases as it is already called in `_app.tsx`.
  * Call this hook when firebase auth functions are required (e.g. `getAuth`, `signOut`, `signInWith`...)
  * Do not call this hook to access user object (Just use `AuthContext.Consumer`)
  */
-export default function useAnonymousLoginIfNeeded() {
+export default function useFirebaseLogin() {
   const [currentUser, setCurrentUser] = useState<User>();
   const [auth, setAuth] = useState<Auth>();
 

--- a/hooks/useFirebaseLogin.ts
+++ b/hooks/useFirebaseLogin.ts
@@ -3,6 +3,8 @@ import { Auth, getAuth, getRedirectResult, onAuthStateChanged, signInAnonymously
 import { useCallback, useEffect, useState } from 'react';
 import usersApi from '../api/usersApi';
 import { openNotification } from '../components/notification/Notifier';
+import { ApiResponse } from '../types/apiResponse';
+import { UserData } from '../types/user';
 import { Nullable } from '../types/utils';
 import { getPreviousUserToken } from '../utils/localStorage/temporaryUserKeyStorage';
 
@@ -27,7 +29,9 @@ export default function useFirebaseLogin() {
         if (result) {
           const oldUserToken = getPreviousUserToken() ?? undefined;
           const newUserToken = await user.getIdToken();
-          usersApi.createAccount(newUserToken, oldUserToken).catch(openNotification);
+          usersApi
+            .createAccount(newUserToken, oldUserToken)
+            .catch((result: ApiResponse<UserData>) => result.messages.forEach((message) => openNotification(message)));
         }
       } else {
         const auth = getAuth();

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import { AxiosInterceptor } from '../api/interceptor';
 import Header from '../components/header/Header';
 import ApplicationNavBar from '../components/navigation/ApplicationNavBar';
 import AuthContext from '../context/AuthContext';
-import useAnonymousLoginIfNeeded from '../hooks/useAnonymousLoginIfNeeded';
+import useFirebaseLogin from '../hooks/useFirebaseLogin';
 import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
@@ -21,9 +21,9 @@ function MyApp({ Component, pageProps }: AppProps) {
       appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
     });
   }, [initializeApp]);
-
   initFirebase();
-  const authContextValue = useAnonymousLoginIfNeeded();
+
+  const authContextValue = useFirebaseLogin();
   return (
     <AuthContext.Provider value={authContextValue}>
       <AxiosInterceptor>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,6 @@
+import { initializeApp } from 'firebase/app';
 import type { AppProps } from 'next/app';
+import { useCallback } from 'react';
 import { SWRConfig } from 'swr';
 import api from '../api/api';
 import { AxiosInterceptor } from '../api/interceptor';
@@ -9,6 +11,18 @@ import useAnonymousLoginIfNeeded from '../hooks/useAnonymousLoginIfNeeded';
 import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const initFirebase = useCallback(() => {
+    initializeApp({
+      apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+      authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+      storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+      messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+      appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+    });
+  }, [initializeApp]);
+
+  initFirebase();
   const authContextValue = useAnonymousLoginIfNeeded();
   return (
     <AuthContext.Provider value={authContextValue}>

--- a/pages/api/user/index.ts
+++ b/pages/api/user/index.ts
@@ -28,7 +28,7 @@ enum MessageType {
 const messages = Object.freeze({
   // POST messages (without oldToken)
   [MessageType.USER_CREATED]: { type: StatusMessageType.SUCCESS, message: 'New user added.' },
-  [MessageType.USER_ALREADY_EXISTS]: { type: StatusMessageType.ERROR, message: 'User already exists.' },
+  [MessageType.USER_ALREADY_EXISTS]: { type: StatusMessageType.SUCCESS, message: 'User already exists.' },
   // POST messages (with oldToken)
   [MessageType.NEW_USER_LINKED]: { type: StatusMessageType.SUCCESS, message: 'Account was linked successfully.' },
   [MessageType.NEW_USER_UNVERIFIED]: { type: StatusMessageType.ERROR, message: 'Account could not be linked.' },
@@ -72,7 +72,7 @@ function handlePost(currentUid: string, req: NextApiRequest, res: NextApiRespons
 async function handlePostWithoutOldToken(currentUid: string, res: NextApiResponse<ApiResponse<UserData>>) {
   const isExisting = (await getUserIfExists(currentUid)) !== null;
   if (isExisting) {
-    return res.status(HttpStatus.CONFLICT).json(createJsonResponse({}, messages[MessageType.USER_ALREADY_EXISTS]));
+    return res.status(HttpStatus.OK).json(createJsonResponse({}, messages[MessageType.USER_ALREADY_EXISTS]));
   }
 
   await prisma.user.create({ data: { uid: currentUid } });

--- a/utils/localStorage/temporaryUserKeyStorage.ts
+++ b/utils/localStorage/temporaryUserKeyStorage.ts
@@ -1,0 +1,13 @@
+const LOCAL_STORAGE_PREVIOUS_USER_KEY = 'pre-redirect-user-key';
+
+export function storePreviousUserToken(oldToken: string) {
+  localStorage.setItem(LOCAL_STORAGE_PREVIOUS_USER_KEY, oldToken);
+}
+
+export function getPreviousUserToken() {
+  return localStorage.getItem(LOCAL_STORAGE_PREVIOUS_USER_KEY);
+}
+
+export function removePreviousUserToken() {
+  localStorage.removeItem(LOCAL_STORAGE_PREVIOUS_USER_KEY);
+}


### PR DESCRIPTION
# Test Plan


## Basic Test (plz halp)

1. Open prisma studio
1. Clear ur cache / open in incognito 
1. Verify new anonymous user has been added.
1. Create application should succeed.
1. Verify on prisma studio that the new application is added
1. Log in to Github
1. Reload page (required because of bug #53)
1. Verify the application you made still exists.
1. Verify on prisma studio that the application has been transferred to the new GitHub uid, and old UID is missing.

## A bit more testing (optional, if you would be so kind):

1. Log out from GitHub (Now should be anonymous)
1. Verify on prisma studio that there is a new UID.
1. Reload page (required because of bug #53)
1. Verify no applications present in page
1. Log in to Github
1. This should succeed, but there should be an alert saying "There is already an account associated with this GitHub profile.".
1. Verify on prisma studio that there is no change in data.

# Changes:

## Api Logic: `/pages/api/*`

1. Creating user (without old token) is now idempotent (will return 201 if created, 200 if exists already).

## NextJS firebase configs

1. Firebase initialisation will happen outside of login hook for clarity. 
1. The init hook is also renamed from `useAnonymousLoginIfNeeded` to `useFirebaseLogin` as it supports linking.2. 

## Client side api business.

1. `processRequest` in `/api/api.ts` is exported for use in non-standard api calls (those that do not use BaseApi)
1. AxiosInterceptor will no longer modify bearer token if already present (only happens in non-standard api calls)
1. UserApi is a non-standard api call. It will not use BaseApi but instead do `axios.post()` so that it can set bearer token itself.

## Local Storage

1. On every GitHub log in operation, we will save the current JWT to local storage (as an old user token). This is a 1 hour expiry token generated by client side firebase. As it is the same that would have been accessible via browser storage, this is no additional security concern
1. On every log out operation, we will empty the old user token from local storage.
1. If linking account is attempted, we will also empty the old user token from local storage

## Creating new account.

1. On logging in, if no user exists, an anonymous account will be created and added to database via POST /user (no linking).

## Linking GitHub account.

1. When the user opens up the application, if firebase detects that it was due to a redirect operation, it will check redirect results.
1. If redirect results are valid, it will carry on to link the new account to the old account. It retrieves the old token from the local storage and attempts to make it happen. If no old token is found, it will simply attempt to create account.
1. If any error messages are returned, notification alerts will be after logging in (e.g. this account already exists, can't be linked).

# Commits:

- Make api endpoint for creating user idempotent.
- Refactor firebase init out of login hook.
- Rename hook `useAnon...` -> `useFirebaseLogin`.
- Update API & firebase login hook.
- Support interceptor not knowing JWT in advance.
- Use local storage to remember old tokens.
- On login/logout, update local storage.
- Update firebase login to handle redirect flow.
- Add notifications if redirect fails.
